### PR TITLE
Add Arena::map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Thunderdome Changelog
 
 ## Unreleased Changes
+* Added `Arena::map` for converting an arena to another, with different value type, preserving indexing.
 
 ## 0.3.0 (2020-10-16)
 * Added `Arena::invalidate` for invalidating indices on-demand, as a faster remove-followed-by-reinsert.

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -288,6 +288,29 @@ impl<T> Arena<T> {
             slot: 0,
         }
     }
+
+    /// Returns an arena with identical indexing and function `f` applied to each value.
+    pub fn map<F, U>(mut self, mut f: F) -> Arena<U>
+    where
+        F: FnMut(T) -> U,
+    {
+        use Entry::*;
+        Arena {
+            storage: self
+                .storage
+                .drain(..)
+                .map(|entry| match entry {
+                    Occupied(OccupiedEntry { generation, value }) => Occupied(OccupiedEntry {
+                        generation,
+                        value: f(value),
+                    }),
+                    Empty(empty) => Empty(empty),
+                })
+                .collect(),
+            len: self.len,
+            first_free: self.first_free,
+        }
+    }
 }
 
 /// Methods exposed only within the crate.


### PR DESCRIPTION
Analogous to `Iterator::map()`, array `::map()`, etc...

My usecase is pretty much typestate pattern; I want to shed parts of stored items that aren't useful anymore, but I also want existing indices to remain valid.

Alternative approach is to allow constructing `Arena<T>` from iterator of `(Index, T)`. This could also help with implementing serialization further down the line.