### PR TITLE
add _by_slot methods and `Index::slot()` accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Added `Index::slot` for extracting the slot portion of an index.
 * Added `Arena::contains_slot` for checking whether a slot is occupied in a given `Arena` and resolving its `Index` if so.
 * Added `Arena::get_by_slot` and `Arena::get_by_slot_mut` for retrieving an entry by its slot, ignoring generation.
-* Renamed `Arena::remove_entry_by_slot` to `Arena::remove_by_slot`, making it public.
+* Added `Arena::remove_by_slot` for removing an entry by its slot, ignoring generation.
 * Added `Arena::contains` for checking whether an `Index` is valid for a given `Arena`.
 * Added `Arena::retain` for conveniently removing entries which do not satisfy a given predicate.
 * Fix `Arena::iter_mut` to return mutable references.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Thunderdome Changelog
 
 ## Unreleased Changes
+* Added `Index::slot` for extracting the slot portion of an index.
+* Added `Arena::contains_slot` for checking whether a slot is occupied in a given `Arena` and resolving its `Index` if so.
+* Added `Arena::get_by_slot` and `Arena::get_by_slot_mut` for retrieving an entry by its slot, ignoring generation.
+* Renamed `Arena::remove_entry_by_slot` to `Arena::remove_by_slot`, making it public.
 * Added `Arena::contains` for checking whether an `Index` is valid for a given `Arena`.
 * Added `Arena::retain` for conveniently removing entries which do not satisfy a given predicate.
 * Fix `Arena::iter_mut` to return mutable references.

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -187,7 +187,9 @@ impl<T> Arena<T> {
         }
     }
 
-    /// Returns true if the given index is valid for the arena.
+    /// Checks to see whether a slot is occupied in the arena, and if it is,
+    /// returns `Some` with the true `Index` of that slot (slot plus generation.)
+    /// Otherwise, returns `None`.
     pub fn contains_slot(&self, slot: u32) -> Option<Index> {
         match self.storage.get(slot as usize) {
             Some(Entry::Occupied(occupied)) => Some(Index {

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -52,8 +52,8 @@ impl Index {
         Self { generation, slot }
     }
 
-    /// Convert this `Index` to its u32 slot index, discarding the `Generation`
-    /// info.
+    /// Convert this `Index` into a slot, discarding its generation. Slots describe a
+    /// location in an [`Arena`] and are reused when entries are removed.
     pub fn slot(self) -> u32 {
         self.slot
     }

--- a/src/drain.rs
+++ b/src/drain.rs
@@ -32,7 +32,7 @@ impl<'a, T> Iterator for Drain<'a, T> {
             // If this entry is occupied, this method will mark it as an empty.
             // Otherwise, we'll continue looping until we've drained all
             // occupied entries from the arena.
-            if let Some((index, value)) = self.arena.remove_entry_by_slot(slot) {
+            if let Some((index, value)) = self.arena.remove_by_slot(slot) {
                 return Some((index, value));
             }
         }

--- a/src/into_iter.rs
+++ b/src/into_iter.rs
@@ -32,7 +32,7 @@ impl<T> Iterator for IntoIter<T> {
             // If this entry is occupied, this method will mark it as an empty.
             // Otherwise, we'll continue looping until we've removed all
             // occupied entries from the arena.
-            if let Some((index, value)) = self.arena.remove_entry_by_slot(slot) {
+            if let Some((index, value)) = self.arena.remove_by_slot(slot) {
                 return Some((index, value));
             }
         }


### PR DESCRIPTION
This PR adds a `.slot()` method to `Index`, allowing its `slot: u32` field to be extracted. It also adds several methods to `Arena` for working with generation-less slots.