### PR TITLE
impl IntoIterator for {&,&mut}Arena

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Thunderdome Changelog
 
 ## Unreleased Changes
+* Implemented `IntoIterator` for `&Arena` and `&mut Arena`.
 
 ## 0.4.0 (2020-11-17)
 * Added `Index::slot` for extracting the slot portion of an index.

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -433,6 +433,24 @@ impl<T> IntoIterator for Arena<T> {
     }
 }
 
+impl<'a, T> IntoIterator for &'a Arena<T> {
+    type Item = (Index, &'a T);
+    type IntoIter = Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut Arena<T> {
+    type Item = (Index, &'a mut T);
+    type IntoIter = IterMut<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
 impl<T> ops::Index<Index> for Arena<T> {
     type Output = T;
 


### PR DESCRIPTION
Currently, `Arena::iter` or `Arena::iter_mut` have to be called to use iterators. This PR adds trait impls that allow idiomatic loop syntax: `for .. in &arena`.

Example:

```rust
use thunderdome::Arena;

fn main() {
    let mut arena = Arena::new();
    arena.insert(1 as usize);
    arena.insert(2);
    arena.insert(3);
    for (index, item) in &arena {
        println!("{:?}, {:?}", index, item);
    }
}
```

Output:

```
Index { slot: 0, generation: Generation(1) }, 1
Index { slot: 1, generation: Generation(1) }, 2
Index { slot: 2, generation: Generation(1) }, 3
```

The iterators return `(index, item)` pairs, but it's not common, so item-only iterator can be preferable.

What would you think? Thank you.
