### PR TITLE
Implement Arena::get2_mut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased Changes
 * Implemented `IntoIterator` for `&Arena` and `&mut Arena`.
+* Added `Arena::get2_mut` for getting two mutable references of different slots at once.
 
 ## 0.4.0 (2020-11-17)
 * Added `Index::slot` for extracting the slot portion of an index.

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -685,6 +685,18 @@ mod test {
     }
 
     #[test]
+    fn get2_mut_same_slot_different_generation() {
+        let mut arena = Arena::new();
+        let foo = arena.insert(100);
+        let mut foo1 = foo;
+        foo1.generation = foo1.generation.next();
+
+        let (foo_handle, foo1_handle) = arena.get2_mut(foo, foo1);
+        assert!(foo_handle.is_some());
+        assert!(foo1_handle.is_none());
+    }
+
+    #[test]
     #[should_panic]
     fn get2_mut_panics() {
         let mut arena = Arena::new();

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -638,6 +638,62 @@ mod test {
     }
 
     #[test]
+    fn get2_mut() {
+        let mut arena = Arena::new();
+        let foo = arena.insert(100);
+        let bar = arena.insert(500);
+
+        let (foo_handle, bar_handle) = arena.get2_mut(foo, bar);
+        let foo_handle = foo_handle.unwrap();
+        let bar_handle = bar_handle.unwrap();
+        *foo_handle = 105;
+        *bar_handle = 505;
+
+        assert_eq!(arena.get(foo), Some(&105));
+        assert_eq!(arena.get(bar), Some(&505));
+    }
+
+    #[test]
+    fn get2_mut_reversed_order() {
+        let mut arena = Arena::new();
+        let foo = arena.insert(100);
+        let bar = arena.insert(500);
+
+        let (bar_handle, foo_handle) = arena.get2_mut(bar, foo);
+        let foo_handle = foo_handle.unwrap();
+        let bar_handle = bar_handle.unwrap();
+        *foo_handle = 105;
+        *bar_handle = 505;
+
+        assert_eq!(arena.get(foo), Some(&105));
+        assert_eq!(arena.get(bar), Some(&505));
+    }
+
+    #[test]
+    fn get2_mut_non_exist_handle() {
+        let mut arena = Arena::new();
+        let foo = arena.insert(100);
+        let bar = arena.insert(500);
+        arena.remove(bar);
+
+        let (bar_handle, foo_handle) = arena.get2_mut(bar, foo);
+        let foo_handle = foo_handle.unwrap();
+        assert!(bar_handle.is_none());
+        *foo_handle = 105;
+
+        assert_eq!(arena.get(foo), Some(&105));
+    }
+
+    #[test]
+    #[should_panic]
+    fn get2_mut_panics() {
+        let mut arena = Arena::new();
+        let foo = arena.insert(100);
+
+        arena.get2_mut(foo, foo);
+    }
+
+    #[test]
     fn insert_remove_insert_capacity() {
         let mut arena = Arena::with_capacity(2);
         assert_eq!(arena.capacity(), 2);

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -246,11 +246,11 @@ impl<T> Arena<T> {
         // a mutable reference to an element to a pointer and back and remain
         // valid.
 
-        let item1 = self.get_mut(index1);
-        let item1_bypass_borrow_checker = item1.map(|x| x as *mut T);
+        // Hold the first value in a pointer to sidestep the borrow checker
+        let item1_ptr = self.get_mut(index1).map(|x| x as *mut T);
 
         let item2 = self.get_mut(index2);
-        let item1 = unsafe { item1_bypass_borrow_checker.map(|x| x.as_mut().unwrap()) };
+        let item1 = unsafe { item1_ptr.map(|x| &mut *x) };
 
         (item1, item2)
     }

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -221,9 +221,9 @@ impl<T> Arena<T> {
         }
     }
 
-    /// Get mutable references to two values inside this arena at once by
-    /// [`Index`], returning `None` if the corresponding index is not contained
-    /// in this arena.
+    /// Get mutable references of two values inside this arena at once by
+    /// [`Index`], returning `None` if the corresponding `index` is not
+    /// contained in this arena.
     ///
     /// # Panics
     ///
@@ -234,7 +234,8 @@ impl<T> Arena<T> {
             panic!("Arena::get2_mut is called with two identical indices");
         }
 
-        // Unsafe notes:
+        // SAFETY NOTES:
+        //
         // - If `index1` and `index2` have different slot number, `item1` and
         //   `item2` would point to different elements.
         // - If `index1` and `index2` have the same slot number, only one could


### PR DESCRIPTION
This PR adds `Arena::get2_mut` that returns mutable reference to two items of different indices at once.

This PR closes #21.

---

Well... there's definitely some code gymnastics inside to implementing this thing in safe Rust. Is there a better way to implement this, ~~or maybe an unsafe implementation could be preferred~~?