### PR TITLE
Avoid `miri` warning for `Arena::get2_mut`

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -247,11 +247,11 @@ impl<T> Arena<T> {
         // a mutable reference to an element to a pointer and back and remain
         // valid.
 
-        // Hold the first value in a pointer to sidestep the borrow checker
         let item1_ptr = self.get_mut(index1).map(|x| x as *mut T);
+        let item2_ptr = self.get_mut(index2).map(|x| x as *mut T);
 
-        let item2 = self.get_mut(index2);
         let item1 = unsafe { item1_ptr.map(|x| &mut *x) };
+        let item2 = unsafe { item2_ptr.map(|x| &mut *x) };
 
         (item1, item2)
     }


### PR DESCRIPTION
#28
This change suppresses [miri] warnings when the raw pointer tracking feature is off.

[miri]: https://github.com/rust-lang/miri

Is this simple change proper "fix"? I'm really not sure

