### PR TITLE
Implement Serde support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        rust_version: [stable, "1.34.1"]
+        rust_version: [stable, "1.36.0"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,12 @@ jobs:
     - name: Run tests
       run: cargo test --verbose
 
+    - name: Build (all features)
+      run: cargo build --verbose --all-features
+
+    - name: Run tests (all features)
+      run: cargo test --verbose --all-features
+
     - name: Rustfmt and Clippy
       run: |
         cargo fmt -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,15 @@ license = "MIT OR Apache-2.0"
 
 [workspace]
 members = ["comparison"]
+
+[package.metadata.docs.rs]
+all-features = true
+
+[features]
+default = []
+
+[dependencies]
+serde = { version = "1.0.133", optional = true }
+
+[dev-dependencies]
+serde_json = "1.0.74"

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ assert_eq!(output, r#"[[1,"Foo"],[1,null],[2,"Baz"]]"#);
 
 ### Minimum Supported Rust Version (MSRV)
 
-Thunderdome supports Rust 1.34.1 and newer. Until Thunderdome reaches 1.0,
+Thunderdome supports Rust 1.36.0 and newer. Until Thunderdome reaches 1.0,
 changes to the MSRV will require major version bumps. After 1.0, MSRV changes
 will only require minor version bumps, but will need significant justification.
 

--- a/src/feature_serde.rs
+++ b/src/feature_serde.rs
@@ -60,7 +60,10 @@ mod test {
         let expected_len = case
             .expected_storage
             .iter()
-            .filter(|x| matches!(x, Entry::Occupied(_)))
+            .filter(|x| match x {
+                Entry::Occupied(_) => true,
+                Entry::Empty(_) => false,
+            })
             .count();
         assert_eq!(de.len(), expected_len);
     }

--- a/src/feature_serde.rs
+++ b/src/feature_serde.rs
@@ -1,0 +1,169 @@
+use serde::{de::Error as _, ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::arena::Arena;
+use crate::generation::Generation;
+
+impl<T: Serialize> Serialize for Arena<T> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut seq = serializer.serialize_seq(Some(self.storage().len()))?;
+
+        for entry in self.storage() {
+            let generation = entry.generation().to_u32();
+            let value = entry.value();
+
+            seq.serialize_element(&(generation, value))?;
+        }
+
+        seq.end()
+    }
+}
+
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for Arena<T> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let sequence = <Vec<(u32, Option<T>)>>::deserialize(deserializer)?;
+        let mut arena: Arena<T> = Arena::with_capacity(sequence.len());
+
+        for (generation, value) in sequence {
+            let generation = Generation::from_u32(generation)
+                .ok_or_else(|| D::Error::custom(format!("Invalid generation {}", generation)))?;
+
+            arena.push_slot(generation, value);
+        }
+
+        Ok(arena)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::fmt::Debug;
+
+    use serde::{de::DeserializeOwned, Serialize};
+
+    use crate::arena::{Arena, EmptyEntry, Entry, OccupiedEntry};
+    use crate::free_pointer::FreePointer;
+    use crate::generation::Generation;
+
+    struct TestCase<T: 'static> {
+        arena: Arena<T>,
+        expected_json: &'static str,
+        expected_storage: Vec<Entry<T>>,
+    }
+
+    fn test<'a, T: Serialize + DeserializeOwned + PartialEq + Debug>(case: TestCase<T>) {
+        let json = serde_json::to_string(&case.arena).unwrap();
+        assert_eq!(json, case.expected_json);
+
+        let de: Arena<T> = serde_json::from_str(&json).unwrap();
+        assert_eq!(de.storage(), &case.expected_storage);
+
+        let expected_len = case
+            .expected_storage
+            .iter()
+            .filter(|x| matches!(x, Entry::Occupied(_)))
+            .count();
+        assert_eq!(de.len(), expected_len);
+    }
+
+    fn occupied<T>(generation: u32, value: T) -> Entry<T> {
+        Entry::Occupied(OccupiedEntry {
+            generation: Generation::from_u32(generation).unwrap(),
+            value,
+        })
+    }
+
+    fn empty<T>(generation: u32, next: Option<u32>) -> Entry<T> {
+        Entry::Empty(EmptyEntry {
+            generation: Generation::from_u32(generation).unwrap(),
+            next_free: next.map(FreePointer::from_slot),
+        })
+    }
+
+    #[test]
+    fn round_trip_empty() {
+        let arena: Arena<u32> = Arena::new();
+
+        test(TestCase {
+            arena,
+            expected_json: "[]",
+            expected_storage: vec![],
+        });
+    }
+
+    #[test]
+    fn all_occupied() {
+        let mut arena: Arena<u32> = Arena::new();
+        arena.insert(70);
+        arena.insert(80);
+        arena.insert(90);
+
+        test(TestCase {
+            arena,
+            expected_json: "[[1,70],[1,80],[1,90]]",
+            expected_storage: vec![occupied(1, 70), occupied(1, 80), occupied(1, 90)],
+        });
+    }
+
+    #[test]
+    fn inner_empty() {
+        let mut arena: Arena<u32> = Arena::new();
+        arena.insert(100);
+        let second = arena.insert(101);
+        arena.insert(102);
+        arena.remove(second).unwrap();
+
+        test(TestCase {
+            arena,
+            expected_json: "[[1,100],[1,null],[1,102]]",
+            expected_storage: vec![occupied(1, 100), empty(1, None), occupied(1, 102)],
+        });
+    }
+
+    #[test]
+    fn trailing_empty() {
+        let mut arena: Arena<u32> = Arena::new();
+        arena.insert(10);
+        arena.insert(11);
+        let last = arena.insert(12);
+        arena.remove(last).unwrap();
+
+        test(TestCase {
+            arena,
+            expected_json: "[[1,10],[1,11],[1,null]]",
+            expected_storage: vec![occupied(1, 10), occupied(1, 11), empty(1, None)],
+        });
+    }
+
+    #[test]
+    fn generations() {
+        let mut arena: Arena<u32> = Arena::new();
+        let mut handle = arena.insert(50);
+        for i in 0..10 {
+            arena.remove(handle);
+            handle = arena.insert(50 + i);
+        }
+
+        test(TestCase {
+            arena,
+            expected_json: "[[11,59]]",
+            expected_storage: vec![occupied(11, 59)],
+        });
+    }
+
+    #[test]
+    fn free_list() {
+        let mut arena: Arena<u32> = Arena::new();
+        let a = arena.insert(300);
+        let b = arena.insert(400);
+        let c = arena.insert(500);
+        arena.remove(a).unwrap();
+        arena.remove(b).unwrap();
+        arena.remove(c).unwrap();
+
+        test(TestCase {
+            arena,
+            expected_json: "[[1,null],[1,null],[1,null]]",
+            expected_storage: vec![empty(1, None), empty(1, Some(0)), empty(1, Some(1))],
+        })
+    }
+}

--- a/src/free_pointer.rs
+++ b/src/free_pointer.rs
@@ -4,7 +4,7 @@ use std::num::NonZeroU32;
 /// to prevent off-by-one errors and leaking unsafety.
 ///
 /// Uses NonZeroU32 to stay small when put inside an `Option`.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(transparent)]
 pub(crate) struct FreePointer(NonZeroU32);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ assert_eq!(output, r#"[[1,"Foo"],[1,null],[2,"Baz"]]"#);
 
 ## Minimum Supported Rust Version (MSRV)
 
-Thunderdome supports Rust 1.34.1 and newer. Until Thunderdome reaches 1.0,
+Thunderdome supports Rust 1.36.0 and newer. Until Thunderdome reaches 1.0,
 changes to the MSRV will require major version bumps. After 1.0, MSRV changes
 will only require minor version bumps, but will need significant justification.
 */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ assert_eq!(arena.get(foo), None);
 | Max Elements                 | 2³²         | 2⁶⁴                | 2³²     | 2⁶⁴  |
 | Non-`Copy` Values            | Yes         | Yes                | Yes     | Yes  |
 | `no_std` Support             | No          | Yes                | Yes     | No   |
-| Serde Support                | No          | Yes                | Yes     | No   |
+| Serde Support                | Yes         | Yes                | Yes     | No   |
 
 * Sizes calculated on rustc `1.44.0-x86_64-pc-windows-msvc`
 * See [the Thunderdome comparison
@@ -58,6 +58,40 @@ assert_eq!(arena.get(foo), None);
 1. Generational indices help solve the [ABA
    Problem](https://en.wikipedia.org/wiki/ABA_problem), which can cause dangling
    keys to mistakenly access newly-inserted data.
+
+## Serde Support
+Enable the `serde` feature to allow serializing and deserializing [`Arena`].
+
+Thunderdome serializes the arena's entire storage, including empty slots, to
+ensure that indexes are not reused.
+
+Here is an example of how [`Arena`] is serialized, using JSON:
+
+```rust
+# #[cfg(feature = "serde")]
+# fn main() {
+use thunderdome::Arena;
+
+let mut arena = Arena::new();
+
+// Foo is inserted and left alone.
+arena.insert("Foo");
+
+// Bar is inserted, and then removed later.
+let bar = arena.insert("Bar");
+
+// Baz is inserted, removed, and reinserted.
+let baz = arena.insert("Baz");
+arena.remove(baz);
+let baz = arena.insert("Baz");
+
+arena.remove(bar);
+
+let output = serde_json::to_string(&arena).unwrap();
+assert_eq!(output, r#"[[1,"Foo"],[1,null],[2,"Baz"]]"#);
+# }
+# #[cfg(not(feature = "serde"))] fn main() {}
+```
 
 ## Minimum Supported Rust Version (MSRV)
 
@@ -76,5 +110,8 @@ mod arena;
 mod free_pointer;
 mod generation;
 pub mod iter;
+
+#[cfg(feature = "serde")]
+mod feature_serde;
 
 pub use crate::arena::{Arena, Index};


### PR DESCRIPTION
Closes #32.

This implements Serde support for `thunderdome::Arena<T>` for any T that has Serde support. Documentation and tests show pretty well what the format is. Notably, empty slots are serialized as well as occupied ones in order to preserve their generation.

I've bumped the crate's MSRV to 1.36.0 to gain support for [`MaybeUninit`](https://doc.rust-lang.org/core/mem/union.MaybeUninit.html), used by Serde. It's a small bump, so I'm not very worried about it.