### PR TITLE
Fix `insert_at` and `insert_at_slot` bug

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -644,6 +644,8 @@ impl<T> ops::IndexMut<Index> for Arena<T> {
 
 #[cfg(test)]
 mod test {
+    use crate::free_pointer::FreePointer;
+
     use super::{Arena, Generation, Index};
 
     use std::mem::size_of;
@@ -756,6 +758,18 @@ mod test {
         assert_eq!(arena.len(), 1);
         assert_eq!(arena.get(index), Some(&5));
         assert_eq!(arena.get_by_slot(42), Some((index, &5)));
+    }
+
+    #[test]
+    fn insert_at_middle() {
+        let mut arena = Arena::new();
+        arena.insert_at_slot(4, 50);
+        arena.insert_at_slot(2, 40);
+
+        let empty = arena.storage.get(3).unwrap().get_empty().unwrap();
+        if empty.next_free != Some(FreePointer::from_slot(1)) {
+            panic!("Invalid free list: {:#?}", arena);
+        }
     }
 
     #[test]

--- a/src/free_pointer.rs
+++ b/src/free_pointer.rs
@@ -5,7 +5,7 @@ use std::num::NonZeroU32;
 /// to prevent off-by-one errors and leaking unsafety.
 ///
 /// Uses NonZeroU32 to stay small when put inside an `Option`.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 #[repr(transparent)]
 pub(crate) struct FreePointer(NonZeroU32);
 


### PR DESCRIPTION
When inserting into a slot in the middle of the free list, the free pointer was mistakenly not updated.

This was due to `Entry::get_empty()` cloning data instead of returning a reference, which would've caught this bug. I've updated the method names, added a mutable version, fixed the function, and added a new test.