### PR TITLE
Add no_std support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        rust_version: [stable, "1.34.1"]
+        rust_version: [stable, "1.36"]
 
     steps:
     - uses: actions/checkout@v2
@@ -26,6 +26,9 @@ jobs:
 
     - name: Build
       run: cargo build --verbose
+
+    - name: Build (no_std)
+      run: cargo build --no-default-features --verbose
 
     - name: Run tests
       run: cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,9 @@ readme = "README.md"
 keywords = ["arena", "slab", "generational"]
 license = "MIT OR Apache-2.0"
 
+[features]
+default = ["std"]
+std = []
+
 [workspace]
 members = ["comparison"]

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ assert_eq!(arena.get(foo), None);
 | `size_of::<Option<Index>>()` | 8           | 24                 | 8       | 16   |
 | Max Elements                 | 2³²         | 2⁶⁴                | 2³²     | 2⁶⁴  |
 | Non-`Copy` Values            | Yes         | Yes                | Yes     | Yes  |
-| `no_std` Support             | No          | Yes                | Yes     | No   |
+| `no_std` Support             | Yes         | Yes                | Yes     | No   |
 | Serde Support                | No          | Yes                | Yes     | No   |
 
 * Sizes calculated on rustc `1.44.0-x86_64-pc-windows-msvc`
@@ -61,12 +61,16 @@ assert_eq!(arena.get(foo), None);
 
 ### Minimum Supported Rust Version (MSRV)
 
-Thunderdome supports Rust 1.34.1 and newer. Until Thunderdome reaches 1.0,
+Thunderdome supports Rust 1.36 and newer. Until Thunderdome reaches 1.0,
 changes to the MSRV will require major version bumps. After 1.0, MSRV changes
 will only require minor version bumps, but will need significant justification.
 
 [`Arena`]: https://docs.rs/thunderdome/latest/thunderdome/struct.Arena.html
 [`Index`]: https://docs.rs/thunderdome/latest/thunderdome/struct.Index.html
+
+## Crate features
+
+By default the `std` feature is enabled. The `std` feature can be disabled to make this crate `no_std` capable.
 
 ## License
 

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -1,6 +1,10 @@
-use std::convert::TryInto;
-use std::mem::replace;
-use std::ops;
+use core::convert::TryInto;
+use core::mem::replace;
+use core::ops;
+
+// Vec is part of the prelude when std is enabled.
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
 use crate::free_pointer::FreePointer;
 use crate::generation::Generation;
@@ -656,7 +660,7 @@ mod test {
 
     use super::{Arena, Generation, Index};
 
-    use std::mem::size_of;
+    use core::mem::size_of;
 
     #[test]
     fn size_of_index() {

--- a/src/free_pointer.rs
+++ b/src/free_pointer.rs
@@ -1,5 +1,5 @@
-use std::fmt;
-use std::num::NonZeroU32;
+use core::fmt;
+use core::num::NonZeroU32;
 
 /// Contains a reference to a free slot in an arena, encapsulating NonZeroU32
 /// to prevent off-by-one errors and leaking unsafety.
@@ -48,6 +48,6 @@ mod test {
     #[test]
     #[should_panic(expected = "u32 overflowed calculating free pointer from u32")]
     fn panic_on_overflow() {
-        let _ = FreePointer::from_slot(std::u32::MAX);
+        let _ = FreePointer::from_slot(core::u32::MAX);
     }
 }

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -1,5 +1,5 @@
-use std::fmt;
-use std::num::NonZeroU32;
+use core::fmt;
+use core::num::NonZeroU32;
 
 /// Tracks the generation of an entry in an arena. Encapsulates NonZeroU32 to
 /// reduce the number of redundant checks needed, as well as enforcing checked
@@ -46,7 +46,7 @@ impl fmt::Debug for Generation {
 mod test {
     use super::Generation;
 
-    use std::num::NonZeroU32;
+    use core::num::NonZeroU32;
 
     #[test]
     fn first_and_next() {
@@ -59,8 +59,8 @@ mod test {
 
     #[test]
     fn wrap_on_overflow() {
-        let max = Generation(NonZeroU32::new(std::u32::MAX).unwrap());
-        assert_eq!(max.0.get(), std::u32::MAX);
+        let max = Generation(NonZeroU32::new(core::u32::MAX).unwrap());
+        assert_eq!(max.0.get(), core::u32::MAX);
 
         let next = max.next();
         assert_eq!(next.0.get(), 1);

--- a/src/iter/drain.rs
+++ b/src/iter/drain.rs
@@ -1,4 +1,4 @@
-use std::iter::{ExactSizeIterator, FusedIterator};
+use core::iter::{ExactSizeIterator, FusedIterator};
 
 use crate::arena::{Arena, Index};
 
@@ -53,7 +53,7 @@ impl<'a, T> Drop for Drain<'a, T> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod test {
     use crate::Arena;
 

--- a/src/iter/into_iter.rs
+++ b/src/iter/into_iter.rs
@@ -1,4 +1,4 @@
-use std::iter::{ExactSizeIterator, FusedIterator};
+use core::iter::{ExactSizeIterator, FusedIterator};
 
 use crate::arena::{Arena, Index};
 
@@ -46,7 +46,7 @@ impl<T> Iterator for IntoIter<T> {
 impl<T> FusedIterator for IntoIter<T> {}
 impl<T> ExactSizeIterator for IntoIter<T> {}
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod test {
     use crate::Arena;
 

--- a/src/iter/iter.rs
+++ b/src/iter/iter.rs
@@ -1,6 +1,6 @@
-use std::convert::TryInto;
-use std::iter::{Enumerate, ExactSizeIterator, FusedIterator};
-use std::slice;
+use core::convert::TryInto;
+use core::iter::{Enumerate, ExactSizeIterator, FusedIterator};
+use core::slice;
 
 use crate::arena::{Entry, Index};
 
@@ -50,7 +50,7 @@ impl<'a, T> Iterator for Iter<'a, T> {
 impl<'a, T> FusedIterator for Iter<'a, T> {}
 impl<'a, T> ExactSizeIterator for Iter<'a, T> {}
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod test {
     use crate::Arena;
 

--- a/src/iter/iter_mut.rs
+++ b/src/iter/iter_mut.rs
@@ -1,6 +1,6 @@
-use std::convert::TryInto;
-use std::iter::{Enumerate, ExactSizeIterator, FusedIterator};
-use std::slice;
+use core::convert::TryInto;
+use core::iter::{Enumerate, ExactSizeIterator, FusedIterator};
+use core::slice;
 
 use crate::arena::{Entry, Index};
 
@@ -50,7 +50,7 @@ impl<'a, T> Iterator for IterMut<'a, T> {
 impl<'a, T> FusedIterator for IterMut<'a, T> {}
 impl<'a, T> ExactSizeIterator for IterMut<'a, T> {}
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod test {
     use crate::Arena;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,10 @@ assert_eq!(arena.get(foo), None);
 Thunderdome supports Rust 1.34.1 and newer. Until Thunderdome reaches 1.0,
 changes to the MSRV will require major version bumps. After 1.0, MSRV changes
 will only require minor version bumps, but will need significant justification.
+
+## Crate features
+
+By default the `std` feature is enabled. The `std` feature can be disabled to make this crate `no_std` capable.
 */
 
 #![forbid(missing_docs)]
@@ -71,6 +75,13 @@ will only require minor version bumps, but will need significant justification.
 // we should usually use methods like `checked_add` and `checked_sub` instead
 // of the `Add` or `Sub` operators.
 #![deny(clippy::integer_arithmetic)]
+
+// TODO: Deny clippy::std_instead_of_core, clippy::std_instead_of_alloc and
+// clippy::alloc_instead_of_core when released.
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
 
 mod arena;
 mod free_pointer;


### PR DESCRIPTION
This necessitates increasing the MSRV to 1.36, the lowest version where the `alloc` crate is stable.

Fixes #4