### PR TITLE
mark functions as constant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        rust_version: [stable, "1.39.0"]
+        rust_version: [stable, "1.47.0"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        rust_version: [stable, "1.36.0"]
+        rust_version: [stable, "1.39.0"]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ assert_eq!(arena.get(foo), None);
 
 ## Minimum Supported Rust Version (MSRV)
 
-Thunderdome supports Rust 1.36.0 and newer. Until Thunderdome reaches 1.0,
+Thunderdome supports Rust 1.39.0 and newer. Until Thunderdome reaches 1.0,
 changes to the MSRV will require major version bumps. After 1.0, MSRV changes
 will only require minor version bumps, but will need significant justification.
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ assert_eq!(arena.get(foo), None);
 
 ## Minimum Supported Rust Version (MSRV)
 
-Thunderdome supports Rust 1.39.0 and newer. Until Thunderdome reaches 1.0,
+Thunderdome supports Rust 1.47.0 and newer. Until Thunderdome reaches 1.0,
 changes to the MSRV will require major version bumps. After 1.0, MSRV changes
 will only require minor version bumps, but will need significant justification.
 

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -31,7 +31,7 @@ impl Index {
     /// Convert this `Index` to an equivalent `u64` representation. Mostly
     /// useful for passing to code outside of Rust.
     #[allow(clippy::integer_arithmetic)]
-    pub fn to_bits(self) -> u64 {
+    pub const fn to_bits(self) -> u64 {
         // This is safe because a `u32` bit-shifted by 32 will still fit in a `u64`.
         ((self.generation.to_u32() as u64) << 32) | (self.slot as u64)
     }
@@ -48,23 +48,27 @@ impl Index {
     /// `Index::to_bits` in 0.4.0 and `Index::from_bits` in 0.4.2 is guaranteed
     /// to work.
     #[allow(clippy::integer_arithmetic)]
-    pub fn from_bits(bits: u64) -> Option<Self> {
+    pub const fn from_bits(bits: u64) -> Option<Self> {
         // By bit-shifting right by 32, we're undoing the left-shift in `to_bits`
         // thus this is okay by the same rationale.
-        let generation = Generation::from_u32((bits >> 32) as u32)?;
+        let generation = match Generation::from_u32((bits >> 32) as u32) {
+            Some(v) => v,
+            None => return None,
+        };
+
         let slot = bits as u32;
 
         Some(Self { generation, slot })
     }
 
     /// Convert this `Index` into a generation, discarding its slot.
-    pub fn generation(self) -> u32 {
+    pub const fn generation(self) -> u32 {
         self.generation.to_u32()
     }
 
     /// Convert this `Index` into a slot, discarding its generation. Slots describe a
     /// location in an [`Arena`] and are reused when entries are removed.
-    pub fn slot(self) -> u32 {
+    pub const fn slot(self) -> u32 {
         self.slot
     }
 }
@@ -115,7 +119,7 @@ pub(crate) struct EmptyEntry {
 
 impl<T> Arena<T> {
     /// Construct an empty arena.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             storage: Vec::new(),
             len: 0,
@@ -134,7 +138,7 @@ impl<T> Arena<T> {
     }
 
     /// Return the number of elements contained in the arena.
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.len as usize
     }
 
@@ -145,7 +149,7 @@ impl<T> Arena<T> {
     }
 
     /// Returns whether the arena is empty.
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.len == 0
     }
 

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -27,12 +27,16 @@ impl Generation {
         Generation(unsafe { NonZeroU32::new_unchecked(next_generation) })
     }
 
-    pub(crate) fn to_u32(self) -> u32 {
+    pub(crate) const fn to_u32(self) -> u32 {
         self.0.get()
     }
 
-    pub(crate) fn from_u32(gen: u32) -> Option<Self> {
-        NonZeroU32::new(gen).map(Generation)
+    pub(crate) const fn from_u32(gen: u32) -> Option<Self> {
+        // match like this since `map` is not constant
+        match NonZeroU32::new(gen) {
+            Some(v) => Some(Generation(v)),
+            None => None,
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ assert_eq!(arena.get(foo), None);
 
 # Minimum Supported Rust Version (MSRV)
 
-Thunderdome supports Rust 1.39.0 and newer. Until Thunderdome reaches 1.0,
+Thunderdome supports Rust 1.47.0 and newer. Until Thunderdome reaches 1.0,
 changes to the MSRV will require major version bumps. After 1.0, MSRV changes
 will only require minor version bumps, but will need significant justification.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ assert_eq!(arena.get(foo), None);
 
 # Minimum Supported Rust Version (MSRV)
 
-Thunderdome supports Rust 1.36.0 and newer. Until Thunderdome reaches 1.0,
+Thunderdome supports Rust 1.39.0 and newer. Until Thunderdome reaches 1.0,
 changes to the MSRV will require major version bumps. After 1.0, MSRV changes
 will only require minor version bumps, but will need significant justification.
 


### PR DESCRIPTION
This PR does three things:
1. Makes `Arena::new` const
2. Updates our MSRV to 1.39 (which is required for Vec::new() to be const)
3. Marks all the low-hanging API fruit as const which require no or highly minimal changes.

I care about 1 (which requires 2), but I don't care much for 3 at all -- some of these changes required refactoring `map` into a `match`, which is less readable (though not terribly), so those changes I do not feel strongly about.

To defend 1 however, I think making `Arena::new` allows it to be constructed in static contexts (notably in a parking_lot::RwLock, which has a const new) with ease. Technically this could cause breakage later on if a new constructor is devised which cannot be made const, but I highly doubt `Arena` will ever not be able to be const.
