### PR TITLE
Use a safe technique to implement `.get2_mut()`

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -378,7 +378,9 @@ impl<T> Arena<T> {
     /// returning `None` if the index is not contained in the arena.
     pub fn get_mut(&mut self, index: Index) -> Option<&mut T> {
         match self.storage.get_mut(index.slot as usize) {
-            Some(entry) => entry.get_value_mut(),
+            Some(Entry::Occupied(occupied)) if occupied.generation == index.generation => {
+                Some(&mut occupied.value)
+            }
             _ => None,
         }
     }

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -94,7 +94,7 @@ impl<T> Entry<T> {
             Entry::Occupied(occupied) if occupied.generation == generation => {
                 Some(&mut occupied.value)
             }
-            Entry::Empty(_) => None,
+            _ => None,
         }
     }
 


### PR DESCRIPTION
Fixes #41 

Uses the same technique that `slab` uses (as mentioned in https://github.com/LPGhatguy/thunderdome/issues/41#issuecomment-1487614744) with some slight tweaks to handle the generations right