### PR TITLE
feat: `DoubleEndedIterator` for `Iter` on `Arena`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Thunderdome Changelog
 
 ## Unreleased Changes
+* Implemented `DoubleEndedIterator` for all iterator types. ([#43])
+
+[#43]: https://github.com/LPGhatguy/thunderdome/pull/43
 
 ## [0.6.1] - 2023-06-24
 * Added `Index::DANGLING`.

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -573,8 +573,7 @@ impl<T> Arena<T> {
     /// Iteration order is not defined.
     pub fn iter(&self) -> Iter<'_, T> {
         Iter {
-            inner: self.storage.iter(),
-            slot: 0,
+            inner: self.storage.iter().enumerate(),
             len: self.len,
         }
     }
@@ -585,8 +584,7 @@ impl<T> Arena<T> {
     /// Iteration order is not defined.
     pub fn iter_mut(&mut self) -> IterMut<'_, T> {
         IterMut {
-            inner: self.storage.iter_mut(),
-            slot: 0,
+            inner: self.storage.iter_mut().enumerate(),
             len: self.len,
         }
     }

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -647,8 +647,8 @@ impl<T> IntoIterator for Arena<T> {
 
     fn into_iter(self) -> Self::IntoIter {
         IntoIter {
-            arena: self,
-            slot: 0,
+            len: self.len,
+            inner: self.storage.into_iter().enumerate(),
         }
     }
 }

--- a/src/iter/into_iter.rs
+++ b/src/iter/into_iter.rs
@@ -52,6 +52,36 @@ impl<T> Iterator for IntoIter<T> {
     }
 }
 
+impl<T> DoubleEndedIterator for IntoIter<T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        loop {
+            if self.len == 0 {
+                return None;
+            }
+
+            match self.inner.next_back()? {
+                (_, Entry::Empty(_)) => (),
+                (slot, Entry::Occupied(occupied)) => {
+                    self.len = self.len.checked_sub(1).unwrap_or_else(|| {
+                        unreachable!("Underflowed u32 trying to iterate Arena in reverse")
+                    });
+
+                    let slot = slot
+                        .try_into()
+                        .unwrap_or_else(|_| unreachable!("Overflowed u32 trying to iterate Arena"));
+
+                    let index = Index {
+                        slot,
+                        generation: occupied.generation,
+                    };
+
+                    return Some((index, occupied.value));
+                }
+            }
+        }
+    }
+}
+
 impl<T> FusedIterator for IntoIter<T> {}
 impl<T> ExactSizeIterator for IntoIter<T> {}
 
@@ -84,5 +114,63 @@ mod test {
         assert_eq!(pairs.len(), 2);
         assert!(pairs.contains(&(one, 1)));
         assert!(pairs.contains(&(two, 2)));
+    }
+
+    #[test]
+    fn iter_rev() {
+        let mut arena = Arena::with_capacity(2);
+        let one = arena.insert(1);
+        let two = arena.insert(2);
+
+        let mut pairs = HashSet::new();
+        let mut iter = arena.into_iter().rev();
+        assert_eq!(iter.size_hint(), (2, Some(2)));
+
+        pairs.insert(iter.next().unwrap());
+        assert_eq!(iter.size_hint(), (1, Some(1)));
+
+        pairs.insert(iter.next().unwrap());
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+
+        assert!(pairs.contains(&(two, 2)));
+        assert!(pairs.contains(&(one, 1)));
+    }
+
+    #[test]
+    fn iter_both_directions() {
+        let mut arena = Arena::with_capacity(2);
+        let one = arena.insert(1);
+        let two = arena.insert(2);
+        let three = arena.insert(3);
+        let four = arena.insert(4);
+
+        let mut pairs = HashSet::new();
+        let mut iter = arena.into_iter();
+        assert_eq!(iter.size_hint(), (4, Some(4)));
+
+        pairs.insert(iter.next().unwrap());
+        assert_eq!(iter.size_hint(), (3, Some(3)));
+
+        pairs.insert(iter.next_back().unwrap());
+        assert_eq!(iter.size_hint(), (2, Some(2)));
+
+        pairs.insert(iter.next_back().unwrap());
+        assert_eq!(iter.size_hint(), (1, Some(1)));
+
+        pairs.insert(iter.next().unwrap());
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+
+        assert_eq!(iter.next_back(), None);
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+
+        assert!(pairs.contains(&(one, 1)));
+        assert!(pairs.contains(&(two, 2)));
+        assert!(pairs.contains(&(three, 3)));
+        assert!(pairs.contains(&(four, 4)));
     }
 }

--- a/src/iter/into_iter.rs
+++ b/src/iter/into_iter.rs
@@ -1,11 +1,18 @@
-use core::iter::{ExactSizeIterator, FusedIterator};
+use core::convert::TryInto;
+use core::iter::{Enumerate, ExactSizeIterator, FusedIterator};
 
-use crate::arena::{Arena, Index};
+#[cfg(feature = "std")]
+use std::vec;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec;
+
+use crate::arena::{Entry, Index};
 
 /// Iterator typed used when an Arena is turned [`IntoIterator`].
 pub struct IntoIter<T> {
-    pub(crate) arena: Arena<T>,
-    pub(crate) slot: u32,
+    pub(crate) len: u32,
+    pub(crate) inner: Enumerate<vec::IntoIter<Entry<T>>>,
 }
 
 impl<T> Iterator for IntoIter<T> {
@@ -13,33 +20,35 @@ impl<T> Iterator for IntoIter<T> {
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            // If there are no entries remaining in the arena, we should always
-            // return None. Using this check instead of comparing with the
-            // arena's size allows us to skip any trailing empty entries.
-            if self.arena.is_empty() {
+            if self.len == 0 {
                 return None;
             }
 
-            // slot may overflow if the arena's underlying storage contains more
-            // than 2^32 elements, but its internal length value was not
-            // changed, as it overflowing would panic before reaching this code.
-            let slot = self.slot;
-            self.slot = self
-                .slot
-                .checked_add(1)
-                .unwrap_or_else(|| panic!("Overflowed u32 trying to into_iter Arena"));
+            match self.inner.next()? {
+                (_, Entry::Empty(_)) => (),
+                (slot, Entry::Occupied(occupied)) => {
+                    self.len = self
+                        .len
+                        .checked_sub(1)
+                        .unwrap_or_else(|| unreachable!("Underflowed u32 trying to iterate Arena"));
 
-            // If this entry is occupied, this method will mark it as an empty.
-            // Otherwise, we'll continue looping until we've removed all
-            // occupied entries from the arena.
-            if let Some((index, value)) = self.arena.remove_by_slot(slot) {
-                return Some((index, value));
+                    let slot = slot
+                        .try_into()
+                        .unwrap_or_else(|_| unreachable!("Overflowed u32 trying to iterate Arena"));
+
+                    let index = Index {
+                        slot,
+                        generation: occupied.generation,
+                    };
+
+                    return Some((index, occupied.value));
+                }
             }
         }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.arena.len(), Some(self.arena.len()))
+        (self.len as usize, Some(self.len as usize))
     }
 }
 

--- a/src/iter/iter.rs
+++ b/src/iter/iter.rs
@@ -15,7 +15,7 @@ impl<'a, T> Iterator for Iter<'a, T> {
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            if self.len == 0 {
+            if self.len == 0 || self.slot > self.len {
                 return None;
             }
 
@@ -46,6 +46,41 @@ impl<'a, T> Iterator for Iter<'a, T> {
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.len as usize, Some(self.len as usize))
+    }
+}
+
+impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        loop {
+            if self.len == 0 || self.slot > self.len {
+                return None;
+            }
+
+            let slot = self
+                .slot
+                .checked_add(self.len.checked_sub(1).unwrap_or_else(|| {
+                    unreachable!("Underflowed u32 trying to iterate Arena in reverse")
+                }))
+                .unwrap_or_else(|| {
+                    unreachable!("Overflowed u32 trying to iterate Arena in reverse")
+                });
+
+            match self.inner.next_back()? {
+                Entry::Empty(_) => (),
+                Entry::Occupied(occupied) => {
+                    self.len = self.len.checked_sub(1).unwrap_or_else(|| {
+                        unreachable!("Underflowed u32 trying to iterate Arena in reverse")
+                    });
+
+                    let index = Index {
+                        slot,
+                        generation: occupied.generation,
+                    };
+
+                    return Some((index, &occupied.value));
+                }
+            }
+        }
     }
 }
 
@@ -80,5 +115,63 @@ mod test {
 
         assert!(pairs.contains(&(one, &1)));
         assert!(pairs.contains(&(two, &2)));
+    }
+
+    #[test]
+    fn iter_rev() {
+        let mut arena = Arena::with_capacity(2);
+        let one = arena.insert(1);
+        let two = arena.insert(2);
+
+        let mut pairs = HashSet::new();
+        let mut iter = arena.iter().rev();
+        assert_eq!(iter.size_hint(), (2, Some(2)));
+
+        pairs.insert(iter.next().unwrap());
+        assert_eq!(iter.size_hint(), (1, Some(1)));
+
+        pairs.insert(iter.next().unwrap());
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+
+        assert!(pairs.contains(&(two, &2)));
+        assert!(pairs.contains(&(one, &1)));
+    }
+
+    #[test]
+    fn iter_both_directions() {
+        let mut arena = Arena::with_capacity(2);
+        let one = arena.insert(1);
+        let two = arena.insert(2);
+        let three = arena.insert(3);
+        let four = arena.insert(4);
+
+        let mut pairs = HashSet::new();
+        let mut iter = arena.iter();
+        assert_eq!(iter.size_hint(), (4, Some(4)));
+
+        pairs.insert(iter.next().unwrap());
+        assert_eq!(iter.size_hint(), (3, Some(3)));
+
+        pairs.insert(iter.next_back().unwrap());
+        assert_eq!(iter.size_hint(), (2, Some(2)));
+
+        pairs.insert(iter.next_back().unwrap());
+        assert_eq!(iter.size_hint(), (1, Some(1)));
+
+        pairs.insert(iter.next().unwrap());
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+
+        assert_eq!(iter.next_back(), None);
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+
+        assert!(pairs.contains(&(one, &1)));
+        assert!(pairs.contains(&(two, &2)));
+        assert!(pairs.contains(&(three, &3)));
+        assert!(pairs.contains(&(four, &4)));
     }
 }

--- a/src/iter/iter.rs
+++ b/src/iter/iter.rs
@@ -15,7 +15,7 @@ impl<'a, T> Iterator for Iter<'a, T> {
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            if self.len == 0 || self.slot > self.len {
+            if self.len == 0 {
                 return None;
             }
 
@@ -50,25 +50,20 @@ impl<'a, T> Iterator for Iter<'a, T> {
 impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
     fn next_back(&mut self) -> Option<Self::Item> {
         loop {
-            if self.len == 0 || self.slot > self.len {
+            if self.len == 0 {
                 return None;
             }
 
-            let slot = self
-                .slot
-                .checked_add(self.len.checked_sub(1).unwrap_or_else(|| {
-                    unreachable!("Underflowed u32 trying to iterate Arena in reverse")
-                }))
-                .unwrap_or_else(|| {
-                    unreachable!("Overflowed u32 trying to iterate Arena in reverse")
-                });
-
             match self.inner.next_back()? {
-                Entry::Empty(_) => (),
-                Entry::Occupied(occupied) => {
+                (_, Entry::Empty(_)) => (),
+                (slot, Entry::Occupied(occupied)) => {
                     self.len = self.len.checked_sub(1).unwrap_or_else(|| {
                         unreachable!("Underflowed u32 trying to iterate Arena in reverse")
                     });
+
+                    let slot = slot
+                        .try_into()
+                        .unwrap_or_else(|_| unreachable!("Overflowed u32 trying to iterate Arena"));
 
                     let index = Index {
                         slot,

--- a/src/iter/iter.rs
+++ b/src/iter/iter.rs
@@ -1,4 +1,5 @@
-use core::iter::{ExactSizeIterator, FusedIterator};
+use core::convert::TryInto;
+use core::iter::{Enumerate, ExactSizeIterator, FusedIterator};
 use core::slice;
 
 use crate::arena::{Entry, Index};
@@ -6,8 +7,7 @@ use crate::arena::{Entry, Index};
 /// See [`Arena::iter`](crate::Arena::iter).
 pub struct Iter<'a, T> {
     pub(crate) len: u32,
-    pub(crate) slot: u32,
-    pub(crate) inner: slice::Iter<'a, Entry<T>>,
+    pub(crate) inner: Enumerate<slice::Iter<'a, Entry<T>>>,
 }
 
 impl<'a, T> Iterator for Iter<'a, T> {
@@ -19,19 +19,17 @@ impl<'a, T> Iterator for Iter<'a, T> {
                 return None;
             }
 
-            let slot = self.slot;
-            self.slot = self
-                .slot
-                .checked_add(1)
-                .unwrap_or_else(|| unreachable!("Overflowed u32 trying to iterate Arena"));
-
             match self.inner.next()? {
-                Entry::Empty(_) => (),
-                Entry::Occupied(occupied) => {
+                (_, Entry::Empty(_)) => (),
+                (slot, Entry::Occupied(occupied)) => {
                     self.len = self
                         .len
                         .checked_sub(1)
                         .unwrap_or_else(|| unreachable!("Underflowed u32 trying to iterate Arena"));
+
+                    let slot = slot
+                        .try_into()
+                        .unwrap_or_else(|_| unreachable!("Overflowed u32 trying to iterate Arena"));
 
                     let index = Index {
                         slot,

--- a/src/iter/iter_mut.rs
+++ b/src/iter/iter_mut.rs
@@ -1,4 +1,5 @@
-use core::iter::{ExactSizeIterator, FusedIterator};
+use core::convert::TryInto;
+use core::iter::{Enumerate, ExactSizeIterator, FusedIterator};
 use core::slice;
 
 use crate::arena::{Entry, Index};
@@ -6,8 +7,7 @@ use crate::arena::{Entry, Index};
 /// See [`Arena::iter_mut`](crate::Arena::iter_mut).
 pub struct IterMut<'a, T> {
     pub(crate) len: u32,
-    pub(crate) slot: u32,
-    pub(crate) inner: slice::IterMut<'a, Entry<T>>,
+    pub(crate) inner: Enumerate<slice::IterMut<'a, Entry<T>>>,
 }
 
 impl<'a, T> Iterator for IterMut<'a, T> {
@@ -19,19 +19,17 @@ impl<'a, T> Iterator for IterMut<'a, T> {
                 return None;
             }
 
-            let slot = self.slot;
-            self.slot = self
-                .slot
-                .checked_add(1)
-                .unwrap_or_else(|| unreachable!("Overflowed u32 trying to iterate Arena"));
-
             match self.inner.next()? {
-                Entry::Empty(_) => continue,
-                Entry::Occupied(occupied) => {
+                (_, Entry::Empty(_)) => (),
+                (slot, Entry::Occupied(occupied)) => {
                     self.len = self
                         .len
                         .checked_sub(1)
                         .unwrap_or_else(|| unreachable!("Underflowed u32 trying to iterate Arena"));
+
+                    let slot = slot
+                        .try_into()
+                        .unwrap_or_else(|_| unreachable!("Overflowed u32 trying to iterate Arena"));
 
                     let index = Index {
                         slot,

--- a/src/iter/iter_mut.rs
+++ b/src/iter/iter_mut.rs
@@ -47,6 +47,36 @@ impl<'a, T> Iterator for IterMut<'a, T> {
     }
 }
 
+impl<'a, T> DoubleEndedIterator for IterMut<'a, T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        loop {
+            if self.len == 0 {
+                return None;
+            }
+
+            match self.inner.next_back()? {
+                (_, Entry::Empty(_)) => (),
+                (slot, Entry::Occupied(occupied)) => {
+                    self.len = self.len.checked_sub(1).unwrap_or_else(|| {
+                        unreachable!("Underflowed u32 trying to iterate Arena in reverse")
+                    });
+
+                    let slot = slot
+                        .try_into()
+                        .unwrap_or_else(|_| unreachable!("Overflowed u32 trying to iterate Arena"));
+
+                    let index = Index {
+                        slot,
+                        generation: occupied.generation,
+                    };
+
+                    return Some((index, &mut occupied.value));
+                }
+            }
+        }
+    }
+}
+
 impl<'a, T> FusedIterator for IterMut<'a, T> {}
 impl<'a, T> ExactSizeIterator for IterMut<'a, T> {}
 
@@ -78,5 +108,63 @@ mod test {
 
         assert!(pairs.contains(&(one, &mut 1)));
         assert!(pairs.contains(&(two, &mut 2)));
+    }
+
+    #[test]
+    fn iter_rev() {
+        let mut arena = Arena::with_capacity(2);
+        let one = arena.insert(1);
+        let two = arena.insert(2);
+
+        let mut pairs = HashSet::new();
+        let mut iter = arena.iter_mut().rev();
+        assert_eq!(iter.size_hint(), (2, Some(2)));
+
+        pairs.insert(iter.next().unwrap());
+        assert_eq!(iter.size_hint(), (1, Some(1)));
+
+        pairs.insert(iter.next().unwrap());
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+
+        assert!(pairs.contains(&(two, &mut 2)));
+        assert!(pairs.contains(&(one, &mut 1)));
+    }
+
+    #[test]
+    fn iter_both_directions() {
+        let mut arena = Arena::with_capacity(2);
+        let one = arena.insert(1);
+        let two = arena.insert(2);
+        let three = arena.insert(3);
+        let four = arena.insert(4);
+
+        let mut pairs = HashSet::new();
+        let mut iter = arena.iter_mut();
+        assert_eq!(iter.size_hint(), (4, Some(4)));
+
+        pairs.insert(iter.next().unwrap());
+        assert_eq!(iter.size_hint(), (3, Some(3)));
+
+        pairs.insert(iter.next_back().unwrap());
+        assert_eq!(iter.size_hint(), (2, Some(2)));
+
+        pairs.insert(iter.next_back().unwrap());
+        assert_eq!(iter.size_hint(), (1, Some(1)));
+
+        pairs.insert(iter.next().unwrap());
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+
+        assert_eq!(iter.next_back(), None);
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+
+        assert!(pairs.contains(&(one, &mut 1)));
+        assert!(pairs.contains(&(two, &mut 2)));
+        assert!(pairs.contains(&(three, &mut 3)));
+        assert!(pairs.contains(&(four, &mut 4)));
     }
 }


### PR DESCRIPTION
Implementation of `DoubleEndedIterator`trait on the `Iter` type for `Arena`, including two additional unit tests `iter_rev()` and `iter_both_directions()` in `iter/iter.rs` to confirm expected behavior.

I'm using `thunderdome` in another project, and I found myself needing to do `arena.iter().collect::<Vec<_>>().into_par_iter().rev()`, which is disgusting and not optimal. I looked into the iterator for `Arena` and saw that it was using a `slice::Iter` internally, which implements `DoubleEndedIterator`, so I made some additions and wrote some tests to confirm it works.

I hope the code aligns with your methodology. Given that `arena.iter()` doesn't define an explicit order, I see no reason why "backwards iteration" would yield undesirable outcomes. I am unsure if the check for `self.slot > self.len` on `next()` and `next_back()` is strictly necessary, but it felt appropriate to include.