### PR TITLE
Add value-only iterators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased Changes
 * Raised MSRV to 1.83.0.
 * Implemented `DoubleEndedIterator` for all iterator types. ([#43])
+* Added `Arena::values` for iterating over values without indexes.
 
 [#43]: https://github.com/LPGhatguy/thunderdome/pull/43
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## Unreleased Changes
 * Raised MSRV to 1.83.0.
 * Implemented `DoubleEndedIterator` for all iterator types. ([#43])
-* Added `Arena::values` for iterating over values without indexes.
-* Added `Arena::values_mut` for mutably iterating over values without indexes.
+* Added `Arena::values` for iterating over values without indexes. ([#19])
+* Added `Arena::values_mut` for mutably iterating over values without indexes. ([#19])
+* Added `Arena::into_values` for consuming the arena and iterating over values. ([#19])
 
 [#43]: https://github.com/LPGhatguy/thunderdome/pull/43
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Raised MSRV to 1.83.0.
 * Implemented `DoubleEndedIterator` for all iterator types. ([#43])
 * Added `Arena::values` for iterating over values without indexes.
+* Added `Arena::values_mut` for mutably iterating over values without indexes.
 
 [#43]: https://github.com/LPGhatguy/thunderdome/pull/43
 

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -8,7 +8,7 @@ use alloc::vec::Vec;
 
 use crate::free_pointer::FreePointer;
 use crate::generation::Generation;
-use crate::iter::{Drain, IntoIter, Iter, IterMut};
+use crate::iter::{Drain, IntoIter, Iter, IterMut, Values};
 
 /// Container that can have elements inserted into it and removed from it.
 ///
@@ -575,6 +575,13 @@ impl<T> Arena<T> {
             inner: self.storage.iter().enumerate(),
             len: self.len,
         }
+    }
+
+    /// Iterate over all of the values contained in the arena.
+    ///
+    /// Iteration order is not defined.
+    pub fn values(&self) -> Values<'_, T> {
+        Values { inner: self.iter() }
     }
 
     /// Iterate over all of the indexes and values contained in the arena, with

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -8,7 +8,7 @@ use alloc::vec::Vec;
 
 use crate::free_pointer::FreePointer;
 use crate::generation::Generation;
-use crate::iter::{Drain, IntoIter, Iter, IterMut, Values};
+use crate::iter::{Drain, IntoIter, Iter, IterMut, Values, ValuesMut};
 
 /// Container that can have elements inserted into it and removed from it.
 ///
@@ -592,6 +592,16 @@ impl<T> Arena<T> {
         IterMut {
             inner: self.storage.iter_mut().enumerate(),
             len: self.len,
+        }
+    }
+
+    /// Iterate over all of the values contained in the arena, with mutable
+    /// access to each value.
+    ///
+    /// Iteration order is not defined.
+    pub fn values_mut(&mut self) -> ValuesMut<'_, T> {
+        ValuesMut {
+            inner: self.iter_mut(),
         }
     }
 

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -8,7 +8,7 @@ use alloc::vec::Vec;
 
 use crate::free_pointer::FreePointer;
 use crate::generation::Generation;
-use crate::iter::{Drain, IntoIter, Iter, IterMut, Values, ValuesMut};
+use crate::iter::{Drain, IntoIter, IntoValues, Iter, IterMut, Values, ValuesMut};
 
 /// Container that can have elements inserted into it and removed from it.
 ///
@@ -602,6 +602,15 @@ impl<T> Arena<T> {
     pub fn values_mut(&mut self) -> ValuesMut<'_, T> {
         ValuesMut {
             inner: self.iter_mut(),
+        }
+    }
+
+    /// Consume the arena and iterate over all values contained in it.
+    ///
+    /// Iteration order is not defined.
+    pub fn into_values(self) -> IntoValues<T> {
+        IntoValues {
+            inner: self.into_iter(),
         }
     }
 

--- a/src/iter/into_values.rs
+++ b/src/iter/into_values.rs
@@ -1,0 +1,119 @@
+use core::iter::{ExactSizeIterator, FusedIterator};
+
+use super::IntoIter;
+
+/// See [`Arena::into_values`](crate::Arena::into_values).
+pub struct IntoValues<T> {
+    pub(crate) inner: IntoIter<T>,
+}
+
+impl<T> Iterator for IntoValues<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|(_, value)| value)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+impl<T> DoubleEndedIterator for IntoValues<T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner.next_back().map(|(_, value)| value)
+    }
+}
+
+impl<T> FusedIterator for IntoValues<T> {}
+impl<T> ExactSizeIterator for IntoValues<T> {}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use crate::Arena;
+
+    use std::collections::HashSet;
+
+    #[test]
+    fn into_values() {
+        let mut arena = Arena::with_capacity(2);
+        arena.insert(1);
+        arena.insert(2);
+
+        let mut values = HashSet::new();
+        let mut iter = arena.into_values();
+        assert_eq!(iter.size_hint(), (2, Some(2)));
+
+        values.insert(iter.next().unwrap());
+        assert_eq!(iter.size_hint(), (1, Some(1)));
+
+        values.insert(iter.next().unwrap());
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+
+        assert_eq!(values.len(), 2);
+        assert!(values.contains(&1));
+        assert!(values.contains(&2));
+    }
+
+    #[test]
+    fn into_values_rev() {
+        let mut arena = Arena::with_capacity(2);
+        arena.insert(1);
+        arena.insert(2);
+
+        let mut values = HashSet::new();
+        let mut iter = arena.into_values().rev();
+        assert_eq!(iter.size_hint(), (2, Some(2)));
+
+        values.insert(iter.next().unwrap());
+        assert_eq!(iter.size_hint(), (1, Some(1)));
+
+        values.insert(iter.next().unwrap());
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+
+        assert!(values.contains(&1));
+        assert!(values.contains(&2));
+    }
+
+    #[test]
+    fn into_values_both_directions() {
+        let mut arena = Arena::with_capacity(2);
+        arena.insert(1);
+        arena.insert(2);
+        arena.insert(3);
+        arena.insert(4);
+
+        let mut values = HashSet::new();
+        let mut iter = arena.into_values();
+        assert_eq!(iter.size_hint(), (4, Some(4)));
+
+        values.insert(iter.next().unwrap());
+        assert_eq!(iter.size_hint(), (3, Some(3)));
+
+        values.insert(iter.next_back().unwrap());
+        assert_eq!(iter.size_hint(), (2, Some(2)));
+
+        values.insert(iter.next_back().unwrap());
+        assert_eq!(iter.size_hint(), (1, Some(1)));
+
+        values.insert(iter.next().unwrap());
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+
+        assert_eq!(iter.next_back(), None);
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+
+        assert!(values.contains(&1));
+        assert!(values.contains(&2));
+        assert!(values.contains(&3));
+        assert!(values.contains(&4));
+    }
+}

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -4,8 +4,10 @@ mod drain;
 mod into_iter;
 mod iter;
 mod iter_mut;
+mod values;
 
 pub use drain::Drain;
 pub use into_iter::IntoIter;
 pub use iter::Iter;
 pub use iter_mut::IterMut;
+pub use values::Values;

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -5,9 +5,11 @@ mod into_iter;
 mod iter;
 mod iter_mut;
 mod values;
+mod values_mut;
 
 pub use drain::Drain;
 pub use into_iter::IntoIter;
 pub use iter::Iter;
 pub use iter_mut::IterMut;
 pub use values::Values;
+pub use values_mut::ValuesMut;

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -2,6 +2,7 @@
 
 mod drain;
 mod into_iter;
+mod into_values;
 mod iter;
 mod iter_mut;
 mod values;
@@ -9,6 +10,7 @@ mod values_mut;
 
 pub use drain::Drain;
 pub use into_iter::IntoIter;
+pub use into_values::IntoValues;
 pub use iter::Iter;
 pub use iter_mut::IterMut;
 pub use values::Values;

--- a/src/iter/values.rs
+++ b/src/iter/values.rs
@@ -1,0 +1,118 @@
+use core::iter::{ExactSizeIterator, FusedIterator};
+
+use super::Iter;
+
+/// See [`Arena::values`](crate::Arena::values).
+pub struct Values<'a, T> {
+    pub(crate) inner: Iter<'a, T>,
+}
+
+impl<'a, T> Iterator for Values<'a, T> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|(_, value)| value)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+impl<'a, T> DoubleEndedIterator for Values<'a, T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner.next_back().map(|(_, value)| value)
+    }
+}
+
+impl<'a, T> FusedIterator for Values<'a, T> {}
+impl<'a, T> ExactSizeIterator for Values<'a, T> {}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use crate::Arena;
+
+    use std::collections::HashSet;
+
+    #[test]
+    fn values() {
+        let mut arena = Arena::with_capacity(2);
+        arena.insert(1);
+        arena.insert(2);
+
+        let mut values = HashSet::new();
+        let mut iter = arena.values();
+        assert_eq!(iter.size_hint(), (2, Some(2)));
+
+        values.insert(*iter.next().unwrap());
+        assert_eq!(iter.size_hint(), (1, Some(1)));
+
+        values.insert(*iter.next().unwrap());
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+
+        assert!(values.contains(&1));
+        assert!(values.contains(&2));
+    }
+
+    #[test]
+    fn values_rev() {
+        let mut arena = Arena::with_capacity(2);
+        arena.insert(1);
+        arena.insert(2);
+
+        let mut values = HashSet::new();
+        let mut iter = arena.values().rev();
+        assert_eq!(iter.size_hint(), (2, Some(2)));
+
+        values.insert(*iter.next().unwrap());
+        assert_eq!(iter.size_hint(), (1, Some(1)));
+
+        values.insert(*iter.next().unwrap());
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+
+        assert!(values.contains(&1));
+        assert!(values.contains(&2));
+    }
+
+    #[test]
+    fn values_both_directions() {
+        let mut arena = Arena::with_capacity(2);
+        arena.insert(1);
+        arena.insert(2);
+        arena.insert(3);
+        arena.insert(4);
+
+        let mut values = HashSet::new();
+        let mut iter = arena.values();
+        assert_eq!(iter.size_hint(), (4, Some(4)));
+
+        values.insert(*iter.next().unwrap());
+        assert_eq!(iter.size_hint(), (3, Some(3)));
+
+        values.insert(*iter.next_back().unwrap());
+        assert_eq!(iter.size_hint(), (2, Some(2)));
+
+        values.insert(*iter.next_back().unwrap());
+        assert_eq!(iter.size_hint(), (1, Some(1)));
+
+        values.insert(*iter.next().unwrap());
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+
+        assert_eq!(iter.next_back(), None);
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+
+        assert!(values.contains(&1));
+        assert!(values.contains(&2));
+        assert!(values.contains(&3));
+        assert!(values.contains(&4));
+    }
+}

--- a/src/iter/values_mut.rs
+++ b/src/iter/values_mut.rs
@@ -1,0 +1,122 @@
+use core::iter::{ExactSizeIterator, FusedIterator};
+
+use super::IterMut;
+
+/// See [`Arena::values_mut`](crate::Arena::values_mut).
+pub struct ValuesMut<'a, T> {
+    pub(crate) inner: IterMut<'a, T>,
+}
+
+impl<'a, T> Iterator for ValuesMut<'a, T> {
+    type Item = &'a mut T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|(_, value)| value)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+impl<'a, T> DoubleEndedIterator for ValuesMut<'a, T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner.next_back().map(|(_, value)| value)
+    }
+}
+
+impl<'a, T> FusedIterator for ValuesMut<'a, T> {}
+impl<'a, T> ExactSizeIterator for ValuesMut<'a, T> {}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use crate::Arena;
+
+    use std::collections::HashSet;
+
+    #[test]
+    fn values_mut() {
+        let mut arena = Arena::with_capacity(2);
+        arena.insert(1);
+        arena.insert(2);
+
+        let mut values = HashSet::new();
+        let mut iter = arena.values_mut();
+        assert_eq!(iter.size_hint(), (2, Some(2)));
+
+        let first = iter.next().unwrap();
+        *first *= 10;
+        values.insert(*first);
+        assert_eq!(iter.size_hint(), (1, Some(1)));
+
+        let second = iter.next().unwrap();
+        *second *= 10;
+        values.insert(*second);
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+
+        assert!(values.contains(&10));
+        assert!(values.contains(&20));
+    }
+
+    #[test]
+    fn values_mut_rev() {
+        let mut arena = Arena::with_capacity(2);
+        arena.insert(1);
+        arena.insert(2);
+
+        let mut values = HashSet::new();
+        let mut iter = arena.values_mut().rev();
+        assert_eq!(iter.size_hint(), (2, Some(2)));
+
+        values.insert(*iter.next().unwrap());
+        assert_eq!(iter.size_hint(), (1, Some(1)));
+
+        values.insert(*iter.next().unwrap());
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+
+        assert!(values.contains(&1));
+        assert!(values.contains(&2));
+    }
+
+    #[test]
+    fn values_mut_both_directions() {
+        let mut arena = Arena::with_capacity(2);
+        arena.insert(1);
+        arena.insert(2);
+        arena.insert(3);
+        arena.insert(4);
+
+        let mut values = HashSet::new();
+        let mut iter = arena.values_mut();
+        assert_eq!(iter.size_hint(), (4, Some(4)));
+
+        values.insert(*iter.next().unwrap());
+        assert_eq!(iter.size_hint(), (3, Some(3)));
+
+        values.insert(*iter.next_back().unwrap());
+        assert_eq!(iter.size_hint(), (2, Some(2)));
+
+        values.insert(*iter.next_back().unwrap());
+        assert_eq!(iter.size_hint(), (1, Some(1)));
+
+        values.insert(*iter.next().unwrap());
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+
+        assert_eq!(iter.next_back(), None);
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+
+        assert!(values.contains(&1));
+        assert!(values.contains(&2));
+        assert!(values.contains(&3));
+        assert!(values.contains(&4));
+    }
+}


### PR DESCRIPTION
This adds value-only iterators (immutable `.values()`, mutable `.values_mut()`, consuming `.into_values()`) like the ones `BTreeMap` and `HashMap` have.

Discussion: https://github.com/LPGhatguy/thunderdome/issues/19