### PR TITLE
Add derive implementations for missing traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Added `Arena::into_values` for consuming the arena and iterating over values. ([#19])
 * Derived `Debug` for all iterator types.
 * Derived `Clone` for `Iter`, `IntoIter`, `Values`, and `IntoValues` iterators.
+* Implemented `Default` for all iterator types except `Drain`.
 
 [#43]: https://github.com/LPGhatguy/thunderdome/pull/43
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Added `Arena::values` for iterating over values without indexes. ([#19])
 * Added `Arena::values_mut` for mutably iterating over values without indexes. ([#19])
 * Added `Arena::into_values` for consuming the arena and iterating over values. ([#19])
+* Derived `Debug` for all iterator types.
+* Derived `Clone` for `Iter`, `IntoIter`, `Values`, and `IntoValues` iterators.
 
 [#43]: https://github.com/LPGhatguy/thunderdome/pull/43
 

--- a/src/free_pointer.rs
+++ b/src/free_pointer.rs
@@ -5,7 +5,7 @@ use core::num::NonZeroU32;
 /// to prevent off-by-one errors and leaking unsafety.
 ///
 /// Uses NonZeroU32 to stay small when put inside an `Option`.
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
 pub(crate) struct FreePointer(NonZeroU32);
 

--- a/src/iter/drain.rs
+++ b/src/iter/drain.rs
@@ -3,6 +3,7 @@ use core::iter::{ExactSizeIterator, FusedIterator};
 use crate::arena::{Arena, Index};
 
 /// See [`Arena::drain`].
+#[derive(Debug)]
 pub struct Drain<'a, T> {
     pub(crate) arena: &'a mut Arena<T>,
     pub(crate) slot: u32,

--- a/src/iter/into_iter.rs
+++ b/src/iter/into_iter.rs
@@ -10,6 +10,7 @@ use alloc::vec;
 use crate::arena::{Entry, Index};
 
 /// Iterator typed used when an Arena is turned [`IntoIterator`].
+#[derive(Clone, Debug)]
 pub struct IntoIter<T> {
     pub(crate) len: u32,
     pub(crate) inner: Enumerate<vec::IntoIter<Entry<T>>>,

--- a/src/iter/into_iter.rs
+++ b/src/iter/into_iter.rs
@@ -86,6 +86,15 @@ impl<T> DoubleEndedIterator for IntoIter<T> {
 impl<T> FusedIterator for IntoIter<T> {}
 impl<T> ExactSizeIterator for IntoIter<T> {}
 
+impl<T> Default for IntoIter<T> {
+    fn default() -> Self {
+        Self {
+            len: 0,
+            inner: vec::IntoIter::<Entry<T>>::default().enumerate(),
+        }
+    }
+}
+
 #[cfg(all(test, feature = "std"))]
 mod test {
     use crate::Arena;

--- a/src/iter/into_values.rs
+++ b/src/iter/into_values.rs
@@ -3,7 +3,7 @@ use core::iter::{ExactSizeIterator, FusedIterator};
 use super::IntoIter;
 
 /// See [`Arena::into_values`](crate::Arena::into_values).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct IntoValues<T> {
     pub(crate) inner: IntoIter<T>,
 }

--- a/src/iter/into_values.rs
+++ b/src/iter/into_values.rs
@@ -3,6 +3,7 @@ use core::iter::{ExactSizeIterator, FusedIterator};
 use super::IntoIter;
 
 /// See [`Arena::into_values`](crate::Arena::into_values).
+#[derive(Clone, Debug)]
 pub struct IntoValues<T> {
     pub(crate) inner: IntoIter<T>,
 }

--- a/src/iter/iter.rs
+++ b/src/iter/iter.rs
@@ -5,6 +5,7 @@ use core::slice;
 use crate::arena::{Entry, Index};
 
 /// See [`Arena::iter`](crate::Arena::iter).
+#[derive(Clone, Debug)]
 pub struct Iter<'a, T> {
     pub(crate) len: u32,
     pub(crate) inner: Enumerate<slice::Iter<'a, Entry<T>>>,

--- a/src/iter/iter.rs
+++ b/src/iter/iter.rs
@@ -81,6 +81,15 @@ impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
 impl<'a, T> FusedIterator for Iter<'a, T> {}
 impl<'a, T> ExactSizeIterator for Iter<'a, T> {}
 
+impl<T> Default for Iter<'_, T> {
+    fn default() -> Self {
+        Self {
+            len: 0,
+            inner: slice::Iter::<Entry<T>>::default().enumerate(),
+        }
+    }
+}
+
 #[cfg(all(test, feature = "std"))]
 mod test {
     use crate::Arena;

--- a/src/iter/iter_mut.rs
+++ b/src/iter/iter_mut.rs
@@ -5,6 +5,7 @@ use core::slice;
 use crate::arena::{Entry, Index};
 
 /// See [`Arena::iter_mut`](crate::Arena::iter_mut).
+#[derive(Debug)]
 pub struct IterMut<'a, T> {
     pub(crate) len: u32,
     pub(crate) inner: Enumerate<slice::IterMut<'a, Entry<T>>>,

--- a/src/iter/iter_mut.rs
+++ b/src/iter/iter_mut.rs
@@ -81,6 +81,15 @@ impl<'a, T> DoubleEndedIterator for IterMut<'a, T> {
 impl<'a, T> FusedIterator for IterMut<'a, T> {}
 impl<'a, T> ExactSizeIterator for IterMut<'a, T> {}
 
+impl<T> Default for IterMut<'_, T> {
+    fn default() -> Self {
+        Self {
+            len: 0,
+            inner: slice::IterMut::<Entry<T>>::default().enumerate(),
+        }
+    }
+}
+
 #[cfg(all(test, feature = "std"))]
 mod test {
     use crate::Arena;

--- a/src/iter/values.rs
+++ b/src/iter/values.rs
@@ -3,6 +3,7 @@ use core::iter::{ExactSizeIterator, FusedIterator};
 use super::Iter;
 
 /// See [`Arena::values`](crate::Arena::values).
+#[derive(Clone, Debug)]
 pub struct Values<'a, T> {
     pub(crate) inner: Iter<'a, T>,
 }

--- a/src/iter/values.rs
+++ b/src/iter/values.rs
@@ -3,7 +3,7 @@ use core::iter::{ExactSizeIterator, FusedIterator};
 use super::Iter;
 
 /// See [`Arena::values`](crate::Arena::values).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Values<'a, T> {
     pub(crate) inner: Iter<'a, T>,
 }

--- a/src/iter/values_mut.rs
+++ b/src/iter/values_mut.rs
@@ -3,7 +3,7 @@ use core::iter::{ExactSizeIterator, FusedIterator};
 use super::IterMut;
 
 /// See [`Arena::values_mut`](crate::Arena::values_mut).
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ValuesMut<'a, T> {
     pub(crate) inner: IterMut<'a, T>,
 }

--- a/src/iter/values_mut.rs
+++ b/src/iter/values_mut.rs
@@ -3,6 +3,7 @@ use core::iter::{ExactSizeIterator, FusedIterator};
 use super::IterMut;
 
 /// See [`Arena::values_mut`](crate::Arena::values_mut).
+#[derive(Debug)]
 pub struct ValuesMut<'a, T> {
     pub(crate) inner: IterMut<'a, T>,
 }


### PR DESCRIPTION
Added derive of `Clone` and `Debug` to `Iter`, `IntoIter`, `Values`, `IntoValues` iterators.

Added derive of `Debug` for `IterMut`, `ValuesMut`, `Drain`.

Added derive of `Eq` on `FreePointer`, which is `pub(crate)`.

Also, implemented `Default` for all iterator types.