### PR TITLE
Entry API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@
 * Derived `Debug` for all iterator types.
 * Derived `Clone` for `Iter`, `IntoIter`, `Values`, and `IntoValues` iterators.
 * Implemented `Default` for all iterator types except `Drain`.
+* Added Entry API. ([#50])
 
 [#19]: https://github.com/LPGhatguy/thunderdome/issues/19
 [#43]: https://github.com/LPGhatguy/thunderdome/pull/43
+[#50]: https://github.com/LPGhatguy/thunderdome/issues/50
 
 ## [0.6.1] - 2023-06-24
 * Added `Index::DANGLING`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Derived `Clone` for `Iter`, `IntoIter`, `Values`, and `IntoValues` iterators.
 * Implemented `Default` for all iterator types except `Drain`.
 
+[#19]: https://github.com/LPGhatguy/thunderdome/issues/19
 [#43]: https://github.com/LPGhatguy/thunderdome/pull/43
 
 ## [0.6.1] - 2023-06-24

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -246,7 +246,7 @@ impl<T> Arena<T> {
             next_fp = self
                 .storage
                 .get(next_fp.slot() as usize)
-                .expect("Empty entry not in storage!")
+                .expect("Empty slot not in storage!")
                 .as_empty()
                 .expect("Slot in free list not actually empty!")
                 .next_free

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -15,7 +15,7 @@ use crate::iter::{Drain, IntoIter, IntoValues, Iter, IterMut, Values, ValuesMut}
 /// Indices use the [`Index`] type, created by inserting values with [`Arena::insert`].
 #[derive(Debug, Clone)]
 pub struct Arena<T> {
-    storage: Vec<Entry<T>>,
+    storage: Vec<Slot<T>>,
     len: u32,
     first_free: Option<FreePointer>,
 }
@@ -83,23 +83,23 @@ impl Index {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) enum Entry<T> {
-    Occupied(OccupiedEntry<T>),
-    Empty(EmptyEntry),
+pub(crate) enum Slot<T> {
+    Occupied(OccupiedSlot<T>),
+    Empty(EmptySlot),
 }
 
-impl<T> Entry<T> {
+impl<T> Slot<T> {
     /// Consume the entry, and if it's occupied, return the value.
     fn into_value(self) -> Option<T> {
         match self {
-            Entry::Occupied(occupied) => Some(occupied.value),
-            Entry::Empty(_) => None,
+            Slot::Occupied(occupied) => Some(occupied.value),
+            Slot::Empty(_) => None,
         }
     }
 
     fn get_value_mut(&mut self, generation: Generation) -> Option<&mut T> {
         match self {
-            Entry::Occupied(occupied) if occupied.generation == generation => {
+            Slot::Occupied(occupied) if occupied.generation == generation => {
                 Some(&mut occupied.value)
             }
             _ => None,
@@ -107,30 +107,30 @@ impl<T> Entry<T> {
     }
 
     /// If the entry is empty, a reference to it.
-    fn as_empty(&self) -> Option<&EmptyEntry> {
+    fn as_empty(&self) -> Option<&EmptySlot> {
         match self {
-            Entry::Empty(empty) => Some(empty),
-            Entry::Occupied(_) => None,
+            Slot::Empty(empty) => Some(empty),
+            Slot::Occupied(_) => None,
         }
     }
 
     /// If the entry is empty, return a mutable reference to it.
-    fn as_empty_mut(&mut self) -> Option<&mut EmptyEntry> {
+    fn as_empty_mut(&mut self) -> Option<&mut EmptySlot> {
         match self {
-            Entry::Empty(empty) => Some(empty),
-            Entry::Occupied(_) => None,
+            Slot::Empty(empty) => Some(empty),
+            Slot::Occupied(_) => None,
         }
     }
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct OccupiedEntry<T> {
+pub(crate) struct OccupiedSlot<T> {
     pub(crate) generation: Generation,
     pub(crate) value: T,
 }
 
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct EmptyEntry {
+pub(crate) struct EmptySlot {
     pub(crate) generation: Generation,
     pub(crate) next_free: Option<FreePointer>,
 }
@@ -207,7 +207,7 @@ impl<T> Arena<T> {
             // of indexing into our storage again. This should avoid an
             // additional bounds check.
             let generation = empty.generation.next();
-            *entry = Entry::Occupied(OccupiedEntry { generation, value });
+            *entry = Slot::Occupied(OccupiedSlot { generation, value });
 
             Index { slot, generation }
         } else {
@@ -220,7 +220,7 @@ impl<T> Arena<T> {
             });
 
             self.storage
-                .push(Entry::Occupied(OccupiedEntry { generation, value }));
+                .push(Slot::Occupied(OccupiedSlot { generation, value }));
 
             Index { slot, generation }
         }
@@ -248,7 +248,7 @@ impl<T> Arena<T> {
                 .get(next_fp.slot() as usize)
                 .expect("Empty entry not in storage!")
                 .as_empty()
-                .expect("Entry in free list not actually empty!")
+                .expect("Slot in free list not actually empty!")
                 .next_free
                 .expect("Hit the end of the free list without finding the target slot!");
         }
@@ -284,17 +284,17 @@ impl<T> Arena<T> {
         //     value.
 
         let (index, old_value) = match self.storage.get_mut(slot as usize) {
-            Some(Entry::Empty(empty)) => {
+            Some(Slot::Empty(empty)) => {
                 let generation = generation.unwrap_or_else(|| empty.generation.next());
                 // We will need to fix up the free list so that whatever pointer previously pointed
                 // to this empty entry will point to the next empty entry after it.
                 let new_next_free = empty.next_free;
                 self.remove_slot_from_free_list(slot, new_next_free);
-                self.storage[slot as usize] = Entry::Occupied(OccupiedEntry { generation, value });
+                self.storage[slot as usize] = Slot::Occupied(OccupiedSlot { generation, value });
 
                 (Index { slot, generation }, None)
             }
-            Some(Entry::Occupied(occupied)) => {
+            Some(Slot::Occupied(occupied)) => {
                 occupied.generation = generation.unwrap_or_else(|| occupied.generation.next());
                 let generation = occupied.generation;
                 let old_value = replace(&mut occupied.value, value);
@@ -308,7 +308,7 @@ impl<T> Arena<T> {
                         unreachable!("Arena storage exceeded what can be represented by a u32")
                     });
 
-                    self.storage.push(Entry::Empty(EmptyEntry {
+                    self.storage.push(Slot::Empty(EmptySlot {
                         generation: Generation::first(),
                         next_free: first_free,
                     }));
@@ -319,7 +319,7 @@ impl<T> Arena<T> {
                 self.first_free = first_free;
                 let generation = generation.unwrap_or_else(Generation::first);
                 self.storage
-                    .push(Entry::Occupied(OccupiedEntry { generation, value }));
+                    .push(Slot::Occupied(OccupiedSlot { generation, value }));
 
                 (Index { slot, generation }, None)
             }
@@ -363,7 +363,7 @@ impl<T> Arena<T> {
     pub fn contains(&self, index: Index) -> bool {
         let entry = self.storage.get(index.slot as usize);
 
-        matches!(entry, Some(Entry::Occupied(occupied)) if occupied.generation == index.generation)
+        matches!(entry, Some(Slot::Occupied(occupied)) if occupied.generation == index.generation)
     }
 
     /// Checks to see whether a slot is occupied in the arena, and if it is,
@@ -371,7 +371,7 @@ impl<T> Arena<T> {
     /// Otherwise, returns `None`.
     pub fn contains_slot(&self, slot: u32) -> Option<Index> {
         match self.storage.get(slot as usize) {
-            Some(Entry::Occupied(occupied)) => Some(Index {
+            Some(Slot::Occupied(occupied)) => Some(Index {
                 slot,
                 generation: occupied.generation,
             }),
@@ -383,7 +383,7 @@ impl<T> Arena<T> {
     /// [`Index`], returning `None` if the index is not contained in the arena.
     pub fn get(&self, index: Index) -> Option<&T> {
         match self.storage.get(index.slot as usize) {
-            Some(Entry::Occupied(occupied)) if occupied.generation == index.generation => {
+            Some(Slot::Occupied(occupied)) if occupied.generation == index.generation => {
                 Some(&occupied.value)
             }
             _ => None,
@@ -446,11 +446,11 @@ impl<T> Arena<T> {
         let entry = self.storage.get_mut(index.slot as usize)?;
 
         match entry {
-            Entry::Occupied(occupied) if occupied.generation == index.generation => {
+            Slot::Occupied(occupied) if occupied.generation == index.generation => {
                 // We can replace an occupied entry with an empty entry with the
                 // same generation. On next insertion, this generation will
                 // increment.
-                let new_entry = Entry::Empty(EmptyEntry {
+                let new_entry = Slot::Empty(EmptySlot {
                     generation: occupied.generation,
                     next_free: self.first_free,
                 });
@@ -481,7 +481,7 @@ impl<T> Arena<T> {
         let entry = self.storage.get_mut(index.slot as usize)?;
 
         match entry {
-            Entry::Occupied(occupied) if occupied.generation == index.generation => {
+            Slot::Occupied(occupied) if occupied.generation == index.generation => {
                 occupied.generation = occupied.generation.next();
 
                 Some(Index {
@@ -498,7 +498,7 @@ impl<T> Arena<T> {
     /// slot is empty.
     pub fn get_by_slot(&self, slot: u32) -> Option<(Index, &T)> {
         match self.storage.get(slot as usize) {
-            Some(Entry::Occupied(occupied)) => {
+            Some(Slot::Occupied(occupied)) => {
                 let index = Index {
                     slot,
                     generation: occupied.generation,
@@ -514,7 +514,7 @@ impl<T> Arena<T> {
     /// slot is empty.
     pub fn get_by_slot_mut(&mut self, slot: u32) -> Option<(Index, &mut T)> {
         match self.storage.get_mut(slot as usize) {
-            Some(Entry::Occupied(occupied)) => {
+            Some(Slot::Occupied(occupied)) => {
                 let index = Index {
                     slot,
                     generation: occupied.generation,
@@ -531,7 +531,7 @@ impl<T> Arena<T> {
         let entry = self.storage.get_mut(slot as usize)?;
 
         match entry {
-            Entry::Occupied(occupied) => {
+            Slot::Occupied(occupied) => {
                 // Construct the index that would be used to access this entry.
                 let index = Index {
                     generation: occupied.generation,
@@ -541,7 +541,7 @@ impl<T> Arena<T> {
                 // This occupied entry will be replaced with an empty one of the
                 // same generation. Generation will be incremented on the next
                 // insert.
-                let next_entry = Entry::Empty(EmptyEntry {
+                let next_entry = Slot::Empty(EmptySlot {
                     generation: occupied.generation,
                     next_free: self.first_free,
                 });
@@ -631,7 +631,7 @@ impl<T> Arena<T> {
     /// Remove all entries in the `Arena` which don't satisfy the provided predicate.
     pub fn retain<F: FnMut(Index, &mut T) -> bool>(&mut self, mut f: F) {
         for (i, entry) in self.storage.iter_mut().enumerate() {
-            if let Entry::Occupied(occupied) = entry {
+            if let Slot::Occupied(occupied) = entry {
                 let index = Index {
                     slot: i as u32,
                     generation: occupied.generation,
@@ -641,7 +641,7 @@ impl<T> Arena<T> {
                     // We can replace an occupied entry with an empty entry with the
                     // same generation. On next insertion, this generation will
                     // increment.
-                    *entry = Entry::Empty(EmptyEntry {
+                    *entry = Slot::Empty(EmptySlot {
                         generation: occupied.generation,
                         next_free: self.first_free,
                     });

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -73,15 +73,12 @@ impl<'a, T> Entry<'a, T> {
     /// the default function.
     ///
     /// This method allows for generating key-derived values for insertion by
-    /// providing the default function a reference to the key that was moved
-    /// during the `.entry(key)` method call.
-    ///
-    /// The reference to the moved key is provided so that cloning or copying
-    /// the key is unnecessary, unlike with `.or_insert_with(|| ... )`.
+    /// providing the default function the key that was moved during the
+    /// `.entry(key)` method call.
     ///
     /// If this entry is vacant, this calls [`Arena::insert_at`] internally, so
     /// it is capable of "resurrecting" an old index.
-    pub fn or_insert_with_key<F: FnOnce(&Index) -> T>(self, default: F) -> &'a mut T {
+    pub fn or_insert_with_key<F: FnOnce(Index) -> T>(self, default: F) -> &'a mut T {
         match self {
             Entry::Occupied(entry) => entry.into_mut(),
             Entry::Vacant(entry) => {
@@ -91,8 +88,8 @@ impl<'a, T> Entry<'a, T> {
         }
     }
 
-    /// Returns a reference to this entry's key.
-    pub fn key(&self) -> &Index {
+    /// Returns this entry's key.
+    pub fn key(&self) -> Index {
         match self {
             Entry::Occupied(entry) => entry.key(),
             Entry::Vacant(entry) => entry.key(),
@@ -127,22 +124,17 @@ impl<'a, T: Default> Entry<'a, T> {
 }
 
 impl<'a, T> VacantEntry<'a, T> {
-    /// Gets a reference to the key that would be used when inserting a value
-    /// through the `VacantEntry`.
-    pub fn key(&self) -> &Index {
-        &self.index
-    }
-
-    /// Take ownership of the key.
-    pub fn into_key(self) -> Index {
+    /// Gets the key that would be used when inserting a value through the
+    /// `VacantEntry`.
+    pub fn key(&self) -> Index {
         self.index
     }
 
     /// Sets the value of the entry with the `VacantEntry`'s key,
     /// and returns a mutable reference to it.
     ///
-    /// If this entry is vacant, this calls [`Arena::insert_at`] internally, so
-    /// it is capable of "resurrecting" an old index.
+    /// This calls [`Arena::insert_at`] internally, so it is capable of
+    /// "resurrecting" an old index.
     pub fn insert(self, value: T) -> &'a mut T {
         self.arena.insert_at(self.index, value);
         self.arena
@@ -152,9 +144,9 @@ impl<'a, T> VacantEntry<'a, T> {
 }
 
 impl<'a, T> OccupiedEntry<'a, T> {
-    /// Gets a reference to the key in the entry.
-    pub fn key(&self) -> &Index {
-        &self.index
+    /// Gets the key in the entry.
+    pub fn key(&self) -> Index {
+        self.index
     }
 
     /// Gets a reference to the value in the entry.
@@ -230,7 +222,7 @@ mod test {
 
         match arena.entry(index) {
             Entry::Occupied(mut entry) => {
-                assert_eq!(entry.key(), &index);
+                assert_eq!(entry.key(), index);
                 assert_eq!(entry.get(), &10);
 
                 *entry.get_mut() = 20;
@@ -332,14 +324,14 @@ mod test {
     }
 
     #[test]
-    fn vacant_into_key() {
+    fn vacant_key() {
         let mut arena = Arena::new();
         let index = arena.insert(1);
         arena.remove(index);
 
         match arena.entry(index) {
             Entry::Vacant(entry) => {
-                assert_eq!(entry.into_key(), index);
+                assert_eq!(entry.key(), index);
             }
             Entry::Occupied(_) => panic!("expected vacant"),
         }

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -1,3 +1,5 @@
+//! Entry API for Thunderdome.
+
 use core::fmt;
 
 use crate::arena::{Arena, Index};
@@ -212,5 +214,148 @@ impl<T> Arena<T> {
         } else {
             Entry::Vacant(VacantEntry { arena: self, index })
         }
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use super::Entry;
+    use crate::arena::{Arena, Index};
+    use crate::generation::Generation;
+
+    #[test]
+    fn occupied_get_modify_remove() {
+        let mut arena = Arena::new();
+        let index = arena.insert(10);
+
+        match arena.entry(index) {
+            Entry::Occupied(mut entry) => {
+                assert_eq!(entry.key(), &index);
+                assert_eq!(entry.get(), &10);
+
+                *entry.get_mut() = 20;
+                assert_eq!(entry.insert(30), 20);
+            }
+            Entry::Vacant(_) => panic!(),
+        }
+
+        assert_eq!(arena[index], 30);
+
+        // Now let's vacate back the slot under index.
+        match arena.entry(index) {
+            Entry::Occupied(entry) => {
+                assert_eq!(entry.remove(), 30);
+            }
+            Entry::Vacant(_) => panic!(),
+        }
+
+        assert!(!arena.contains(index));
+    }
+
+    #[test]
+    fn vacant_or_insert_on_empty_slot() {
+        let mut arena = Arena::new();
+        let index = arena.insert(1);
+        arena.remove(index);
+
+        let value = arena.entry(index).or_insert(5);
+        assert_eq!(*value, 5);
+        assert_eq!(arena[index], 5);
+    }
+
+    #[test]
+    fn vacant_or_insert_out_of_bounds() {
+        let mut arena = Arena::new();
+        let index = Index {
+            slot: 3,
+            generation: Generation::first(),
+        };
+
+        arena.entry(index).or_insert(42);
+        assert_eq!(arena[index], 42);
+        // `.len()` is not contiguous length, but number of occupied slots.
+        assert_eq!(arena.len(), 1);
+    }
+
+    #[test]
+    fn vacant_wrong_generation_displaces() {
+        let mut arena = Arena::new();
+        let first = arena.insert("first");
+        let invalidated = first;
+        let second = arena.invalidate(first).unwrap();
+
+        assert!(matches!(arena.entry(invalidated), Entry::Vacant(_)));
+        assert!(matches!(arena.entry(second), Entry::Occupied(_)));
+
+        // Entry API, just like `.insert_at()`, can resurrect an invalidated
+        // index.
+        arena.entry(invalidated).or_insert("resurrected");
+        assert_eq!(arena[invalidated], "resurrected");
+        assert!(!arena.contains(second));
+    }
+
+    #[test]
+    fn and_modify_then_or_insert() {
+        let mut arena = Arena::new();
+        let index = arena.insert(1);
+        arena.remove(index);
+
+        // Nothing exists on index, so += 10 is not done.
+        arena.entry(index).and_modify(|v| *v += 10).or_insert(5);
+        assert_eq!(arena[index], 5);
+
+        // Previous or_insert(5) filled a slot, so += 10 works now.
+        arena.entry(index).and_modify(|v| *v += 10).or_insert(5);
+        assert_eq!(arena[index], 15);
+    }
+
+    #[test]
+    fn or_default() {
+        let mut arena = Arena::new();
+        let index = arena.insert(1);
+        arena.remove(index);
+
+        arena.entry(index).or_default();
+        assert_eq!(arena[index], 0);
+    }
+
+    #[test]
+    fn or_insert_with_key() {
+        let mut arena = Arena::new();
+        let index = arena.insert(0);
+        arena.remove(index);
+
+        arena
+            .entry(index)
+            .or_insert_with_key(|key| key.slot() as i32 + 7);
+        assert_eq!(arena[index], index.slot() as i32 + 7);
+    }
+
+    #[test]
+    fn vacant_into_key() {
+        let mut arena = Arena::new();
+        let index = arena.insert(1);
+        arena.remove(index);
+
+        match arena.entry(index) {
+            Entry::Vacant(entry) => {
+                assert_eq!(entry.into_key(), index);
+            }
+            Entry::Occupied(_) => panic!("expected vacant"),
+        }
+    }
+
+    #[test]
+    fn occupied_into_mut() {
+        let mut arena = Arena::new();
+        let index = arena.insert(1);
+
+        let value: &mut i32 = match arena.entry(index) {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(_) => panic!("expected occupied"),
+        };
+
+        *value = 9;
+        assert_eq!(arena[index], 9); // Mutable reference works.
     }
 }

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -1,0 +1,216 @@
+use core::fmt;
+
+use crate::arena::{Arena, Index};
+
+/// A view into a single entry in an [`Arena`], which may either be vacant or
+/// occupied.
+///
+/// This `enum` is constructed from the [`entry`] method on [`Arena`].
+///
+/// [`entry`]: Arena::entry
+pub enum Entry<'a, T> {
+    /// A vacant entry.
+    Vacant(VacantEntry<'a, T>),
+
+    /// An occupied entry.
+    Occupied(OccupiedEntry<'a, T>),
+}
+
+impl<T: fmt::Debug> fmt::Debug for Entry<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Entry::Vacant(v) => f.debug_tuple("Entry").field(v).finish(),
+            Entry::Occupied(o) => f.debug_tuple("Entry").field(o).finish(),
+        }
+    }
+}
+
+/// A view into a vacant entry in an [`Arena`].
+/// It is part of the [`Entry`] enum.
+#[derive(Debug)]
+pub struct VacantEntry<'a, T> {
+    arena: &'a mut Arena<T>,
+    index: Index,
+}
+
+/// A view into an occupied entry in an [`Arena`].
+/// It is part of the [`Entry`] enum.
+#[derive(Debug)]
+pub struct OccupiedEntry<'a, T> {
+    arena: &'a mut Arena<T>,
+    index: Index,
+}
+
+impl<'a, T> Entry<'a, T> {
+    /// Ensures a value is in the entry by inserting the default if empty, and
+    /// returns a mutable reference to the value in the entry.
+    ///
+    /// If this entry is vacant, this calls [`Arena::insert_at`] internally, so
+    /// it is capable of "resurrecting" an old index.
+    pub fn or_insert(self, default: T) -> &'a mut T {
+        match self {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => entry.insert(default),
+        }
+    }
+
+    /// Ensures a value is in the entry by inserting the result of the default
+    /// function if empty, and returns a mutable reference to the value in the
+    /// entry.
+    ///
+    /// If this entry is vacant, this calls [`Arena::insert_at`] internally, so
+    /// it is capable of "resurrecting" an old index.
+    pub fn or_insert_with<F: FnOnce() -> T>(self, default: F) -> &'a mut T {
+        match self {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => entry.insert(default()),
+        }
+    }
+
+    /// Ensures a value is in the entry by inserting, if empty, the result of
+    /// the default function.
+    ///
+    /// This method allows for generating key-derived values for insertion by
+    /// providing the default function a reference to the key that was moved
+    /// during the `.entry(key)` method call.
+    ///
+    /// The reference to the moved key is provided so that cloning or copying
+    /// the key is unnecessary, unlike with `.or_insert_with(|| ... )`.
+    ///
+    /// If this entry is vacant, this calls [`Arena::insert_at`] internally, so
+    /// it is capable of "resurrecting" an old index.
+    pub fn or_insert_with_key<F: FnOnce(&Index) -> T>(self, default: F) -> &'a mut T {
+        match self {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => {
+                let value = default(entry.key());
+                entry.insert(value)
+            }
+        }
+    }
+
+    /// Returns a reference to this entry's key.
+    pub fn key(&self) -> &Index {
+        match self {
+            Entry::Occupied(entry) => entry.key(),
+            Entry::Vacant(entry) => entry.key(),
+        }
+    }
+
+    /// Provides in-place mutable access to an occupied entry before any
+    /// potential inserts into the arena.
+    pub fn and_modify<F>(self, f: F) -> Self
+    where
+        F: FnOnce(&mut T),
+    {
+        match self {
+            Entry::Occupied(mut entry) => {
+                f(entry.get_mut());
+                Entry::Occupied(entry)
+            }
+            Entry::Vacant(entry) => Entry::Vacant(entry),
+        }
+    }
+}
+
+impl<'a, T: Default> Entry<'a, T> {
+    /// Ensures a value is in the entry by inserting the default value if empty,
+    /// and returns a mutable reference to the value in the entry.
+    ///
+    /// If this entry is vacant, this calls [`Arena::insert_at`] internally, so
+    /// it is capable of "resurrecting" an old index.
+    pub fn or_default(self) -> &'a mut T {
+        self.or_insert_with(Default::default)
+    }
+}
+
+impl<'a, T> VacantEntry<'a, T> {
+    /// Gets a reference to the key that would be used when inserting a value
+    /// through the `VacantEntry`.
+    pub fn key(&self) -> &Index {
+        &self.index
+    }
+
+    /// Take ownership of the key.
+    pub fn into_key(self) -> Index {
+        self.index
+    }
+
+    /// Sets the value of the entry with the `VacantEntry`'s key,
+    /// and returns a mutable reference to it.
+    ///
+    /// If this entry is vacant, this calls [`Arena::insert_at`] internally, so
+    /// it is capable of "resurrecting" an old index.
+    pub fn insert(self, value: T) -> &'a mut T {
+        self.arena.insert_at(self.index, value);
+        self.arena
+            .get_mut(self.index)
+            .unwrap_or_else(|| unreachable!("insert_at must create an occupied entry"))
+    }
+}
+
+impl<'a, T> OccupiedEntry<'a, T> {
+    /// Gets a reference to the key in the entry.
+    pub fn key(&self) -> &Index {
+        &self.index
+    }
+
+    /// Gets a reference to the value in the entry.
+    pub fn get(&self) -> &T {
+        self.arena
+            .get(self.index)
+            .unwrap_or_else(|| unreachable!("OccupiedEntry points to a vacant slot"))
+    }
+
+    /// Gets a mutable reference to the value in the entry.
+    ///
+    /// If you need a reference to the `OccupiedEntry` that may outlive the
+    /// destruction of the `Entry` value, see [`into_mut`].
+    ///
+    /// [`into_mut`]: OccupiedEntry::into_mut
+    pub fn get_mut(&mut self) -> &mut T {
+        self.arena
+            .get_mut(self.index)
+            .unwrap_or_else(|| unreachable!("OccupiedEntry points to a vacant slot"))
+    }
+
+    /// Converts the entry into a mutable reference to its value.
+    ///
+    /// If you need multiple references to the `OccupiedEntry`, see [`get_mut`].
+    ///
+    /// [`get_mut`]: OccupiedEntry::get_mut
+    pub fn into_mut(self) -> &'a mut T {
+        self.arena
+            .get_mut(self.index)
+            .unwrap_or_else(|| unreachable!("OccupiedEntry points to a vacant slot"))
+    }
+
+    /// Sets the value of the entry with the `OccupiedEntry`'s key,
+    /// and returns the entry's old value.
+    pub fn insert(&mut self, value: T) -> T {
+        core::mem::replace(self.get_mut(), value)
+    }
+
+    /// Takes the value of the entry out of the arena, and returns it.
+    pub fn remove(self) -> T {
+        self.arena
+            .remove(self.index)
+            .unwrap_or_else(|| unreachable!("OccupiedEntry points to a vacant slot"))
+    }
+}
+
+impl<T> Arena<T> {
+    /// Gets the given key's corresponding entry in the arena for in-place
+    /// manipulation.
+    ///
+    /// The entry is occupied if `index` is currently contained in the arena,
+    /// and vacant otherwise (that is, when the slot is empty, out of bounds, or
+    /// occupied by a different generation).
+    pub fn entry(&mut self, index: Index) -> Entry<'_, T> {
+        if self.contains(index) {
+            Entry::Occupied(OccupiedEntry { arena: self, index })
+        } else {
+            Entry::Vacant(VacantEntry { arena: self, index })
+        }
+    }
+}

--- a/src/iter/into_iter.rs
+++ b/src/iter/into_iter.rs
@@ -7,13 +7,13 @@ use std::vec;
 #[cfg(not(feature = "std"))]
 use alloc::vec;
 
-use crate::arena::{Entry, Index};
+use crate::arena::{Index, Slot};
 
 /// Iterator typed used when an Arena is turned [`IntoIterator`].
 #[derive(Clone, Debug)]
 pub struct IntoIter<T> {
     pub(crate) len: u32,
-    pub(crate) inner: Enumerate<vec::IntoIter<Entry<T>>>,
+    pub(crate) inner: Enumerate<vec::IntoIter<Slot<T>>>,
 }
 
 impl<T> Iterator for IntoIter<T> {
@@ -26,8 +26,8 @@ impl<T> Iterator for IntoIter<T> {
             }
 
             match self.inner.next()? {
-                (_, Entry::Empty(_)) => (),
-                (slot, Entry::Occupied(occupied)) => {
+                (_, Slot::Empty(_)) => (),
+                (slot, Slot::Occupied(occupied)) => {
                     self.len = self
                         .len
                         .checked_sub(1)
@@ -61,8 +61,8 @@ impl<T> DoubleEndedIterator for IntoIter<T> {
             }
 
             match self.inner.next_back()? {
-                (_, Entry::Empty(_)) => (),
-                (slot, Entry::Occupied(occupied)) => {
+                (_, Slot::Empty(_)) => (),
+                (slot, Slot::Occupied(occupied)) => {
                     self.len = self.len.checked_sub(1).unwrap_or_else(|| {
                         unreachable!("Underflowed u32 trying to iterate Arena in reverse")
                     });
@@ -90,7 +90,7 @@ impl<T> Default for IntoIter<T> {
     fn default() -> Self {
         Self {
             len: 0,
-            inner: vec::IntoIter::<Entry<T>>::default().enumerate(),
+            inner: vec::IntoIter::<Slot<T>>::default().enumerate(),
         }
     }
 }

--- a/src/iter/iter.rs
+++ b/src/iter/iter.rs
@@ -2,13 +2,13 @@ use core::convert::TryInto;
 use core::iter::{Enumerate, ExactSizeIterator, FusedIterator};
 use core::slice;
 
-use crate::arena::{Entry, Index};
+use crate::arena::{Index, Slot};
 
 /// See [`Arena::iter`](crate::Arena::iter).
 #[derive(Clone, Debug)]
 pub struct Iter<'a, T> {
     pub(crate) len: u32,
-    pub(crate) inner: Enumerate<slice::Iter<'a, Entry<T>>>,
+    pub(crate) inner: Enumerate<slice::Iter<'a, Slot<T>>>,
 }
 
 impl<'a, T> Iterator for Iter<'a, T> {
@@ -21,8 +21,8 @@ impl<'a, T> Iterator for Iter<'a, T> {
             }
 
             match self.inner.next()? {
-                (_, Entry::Empty(_)) => (),
-                (slot, Entry::Occupied(occupied)) => {
+                (_, Slot::Empty(_)) => (),
+                (slot, Slot::Occupied(occupied)) => {
                     self.len = self
                         .len
                         .checked_sub(1)
@@ -56,8 +56,8 @@ impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
             }
 
             match self.inner.next_back()? {
-                (_, Entry::Empty(_)) => (),
-                (slot, Entry::Occupied(occupied)) => {
+                (_, Slot::Empty(_)) => (),
+                (slot, Slot::Occupied(occupied)) => {
                     self.len = self.len.checked_sub(1).unwrap_or_else(|| {
                         unreachable!("Underflowed u32 trying to iterate Arena in reverse")
                     });
@@ -85,7 +85,7 @@ impl<T> Default for Iter<'_, T> {
     fn default() -> Self {
         Self {
             len: 0,
-            inner: slice::Iter::<Entry<T>>::default().enumerate(),
+            inner: slice::Iter::<Slot<T>>::default().enumerate(),
         }
     }
 }

--- a/src/iter/iter_mut.rs
+++ b/src/iter/iter_mut.rs
@@ -2,13 +2,13 @@ use core::convert::TryInto;
 use core::iter::{Enumerate, ExactSizeIterator, FusedIterator};
 use core::slice;
 
-use crate::arena::{Entry, Index};
+use crate::arena::{Index, Slot};
 
 /// See [`Arena::iter_mut`](crate::Arena::iter_mut).
 #[derive(Debug)]
 pub struct IterMut<'a, T> {
     pub(crate) len: u32,
-    pub(crate) inner: Enumerate<slice::IterMut<'a, Entry<T>>>,
+    pub(crate) inner: Enumerate<slice::IterMut<'a, Slot<T>>>,
 }
 
 impl<'a, T> Iterator for IterMut<'a, T> {
@@ -21,8 +21,8 @@ impl<'a, T> Iterator for IterMut<'a, T> {
             }
 
             match self.inner.next()? {
-                (_, Entry::Empty(_)) => (),
-                (slot, Entry::Occupied(occupied)) => {
+                (_, Slot::Empty(_)) => (),
+                (slot, Slot::Occupied(occupied)) => {
                     self.len = self
                         .len
                         .checked_sub(1)
@@ -56,8 +56,8 @@ impl<'a, T> DoubleEndedIterator for IterMut<'a, T> {
             }
 
             match self.inner.next_back()? {
-                (_, Entry::Empty(_)) => (),
-                (slot, Entry::Occupied(occupied)) => {
+                (_, Slot::Empty(_)) => (),
+                (slot, Slot::Occupied(occupied)) => {
                     self.len = self.len.checked_sub(1).unwrap_or_else(|| {
                         unreachable!("Underflowed u32 trying to iterate Arena in reverse")
                     });
@@ -85,7 +85,7 @@ impl<T> Default for IterMut<'_, T> {
     fn default() -> Self {
         Self {
             len: 0,
-            inner: slice::IterMut::<Entry<T>>::default().enumerate(),
+            inner: slice::IterMut::<Slot<T>>::default().enumerate(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,8 +83,10 @@ will only require minor version bumps, but will need significant justification.
 extern crate alloc;
 
 mod arena;
+pub mod entry;
 mod free_pointer;
 mod generation;
 pub mod iter;
 
 pub use crate::arena::{Arena, Index};
+pub use crate::entry::{Entry, OccupiedEntry, VacantEntry};


### PR DESCRIPTION
This PR adds Entry API like in [`BtreeMap`](https://doc.rust-lang.org/std/collections/struct.BTreeMap.html#entry-api), [`HashMap`](https://doc.rust-lang.org/std/collections/struct.HashMap.html#entry-api), [`indexmap::IndexMap`](https://docs.rs/indexmap/latest/indexmap/map/enum.Entry.html), to `thunderdome::Arena`. The current internal (they are non-`pub`) `*Entry` (`Entry`, `OccupiedEntry`, `EmptyEntry`) types were renamed to `*Slot` (`Slot`, `OccupiedSlot`, `EmptySlot`) to avoid confusing them with the Entry API's entry types.