### PR TITLE
feat: added Arena::next_index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@
 * Derived `Clone` for `Iter`, `IntoIter`, `Values`, and `IntoValues` iterators.
 * Implemented `Default` for all iterator types except `Drain`.
 * Added Entry API. ([#50])
+* Added `Arena::next_index` ([#51]) for predicting the key of the next inserted value without mutating the arena.
 
 [#19]: https://github.com/LPGhatguy/thunderdome/issues/19
 [#43]: https://github.com/LPGhatguy/thunderdome/pull/43
 [#50]: https://github.com/LPGhatguy/thunderdome/issues/50
+[#51]: https://github.com/LPGhatguy/thunderdome/pull/54
 
 ## [0.6.1] - 2023-06-24
 * Added `Index::DANGLING`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,12 @@
 * Derived `Clone` for `Iter`, `IntoIter`, `Values`, and `IntoValues` iterators.
 * Implemented `Default` for all iterator types except `Drain`.
 * Added Entry API. ([#50])
-* Added `Arena::next_index` ([#51]) for predicting the key of the next inserted value without mutating the arena.
+* Added `Arena::next_index` ([#54]) for predicting the key of the next inserted value without mutating the arena.
 
 [#19]: https://github.com/LPGhatguy/thunderdome/issues/19
 [#43]: https://github.com/LPGhatguy/thunderdome/pull/43
 [#50]: https://github.com/LPGhatguy/thunderdome/issues/50
-[#51]: https://github.com/LPGhatguy/thunderdome/pull/54
+[#54]: https://github.com/LPGhatguy/thunderdome/pull/54
 
 ## [0.6.1] - 2023-06-24
 * Added `Index::DANGLING`.

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -226,6 +226,47 @@ impl<T> Arena<T> {
         }
     }
 
+    /// Compute the `Index` that the next call to [`Arena::insert`] would produce,
+    /// without mutating the arena.
+    ///
+    /// This is the equivalent of calling [`Arena::vacant_entry`] and then [`Entry::insert`] without requiring
+    /// a unique borrow on the arena.
+    ///
+    /// ## Limitations
+    ///
+    /// The key produced will never immediately point to an occupied slot, but it may point to a location outside
+    /// the collection which will be created on the next call to [`Arena::insert`].
+    /// If, after calling this function, the arena is mutated in a way that changes its free list or storage
+    /// length — for example via [`Arena::insert`], [`Arena::remove`], etc — then the results of this function
+    /// are no longer accurate to what will be returned from the next [`Arena::insert`] call.
+    pub fn next_index(&self) -> Index {
+        if let Some(free_pointer) = self.first_free {
+            let slot = free_pointer.slot();
+            let empty = self
+                .storage
+                .get(slot as usize)
+                .unwrap_or_else(|| {
+                    unreachable!("first_free pointed past the end of the arena's storage")
+                })
+                .as_empty()
+                .unwrap_or_else(|| unreachable!("first_free pointed to an occupied entry"));
+
+            Index {
+                slot,
+                generation: empty.generation.next(),
+            }
+        } else {
+            let slot: u32 = self.storage.len().try_into().unwrap_or_else(|_| {
+                unreachable!("Arena storage exceeded what can be represented by a u32")
+            });
+
+            Index {
+                slot,
+                generation: Generation::first(),
+            }
+        }
+    }
+
     /// Traverse the free list and remove this known-empty slot from it, given the slot to remove
     /// and the `next_free` pointer of that slot.
     fn remove_slot_from_free_list(&mut self, slot: u32, new_next_free: Option<FreePointer>) {
@@ -981,5 +1022,48 @@ mod test {
     fn index_bits_none_on_zero_generation() {
         let index = Index::from_bits(0x0000_0000_DEAD_BEEF);
         assert_eq!(index, None);
+    }
+
+    #[test]
+    fn next_index_matches_insert() {
+        let mut arena = Arena::new();
+        let predicted = arena.next_index();
+        let actual = arena.insert(1);
+        assert_eq!(predicted, actual);
+    }
+
+    #[test]
+    fn next_index_reuses_freed_slot() {
+        let mut arena = Arena::new();
+        let a = arena.insert(1);
+        arena.insert(2);
+        arena.remove(a);
+
+        let predicted = arena.next_index();
+        assert_eq!(predicted.slot(), a.slot());
+        assert_ne!(predicted.generation, a.generation);
+
+        let actual = arena.insert(3);
+        assert_eq!(predicted, actual);
+    }
+
+    #[test]
+    fn next_index_does_not_mutate() {
+        let mut arena = Arena::new();
+        arena.insert(1);
+
+        // Calling this repeatedly should keep predicting the same index.
+        assert_eq!(arena.next_index(), arena.next_index());
+    }
+
+    #[test]
+    fn next_index_is_not_magic() {
+        let mut arena = Arena::new();
+        let next = arena.next_index();
+        arena.insert(1);
+        let next_next_insert = arena.insert(1);
+
+        // we moved the goalpost, so the next_index won't be accurate anymore
+        assert_ne!(next, next_next_insert);
     }
 }

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -232,13 +232,7 @@ impl<T> Arena<T> {
     /// This is the equivalent of calling [`Arena::vacant_entry`] and then [`Entry::insert`] without requiring
     /// a unique borrow on the arena.
     ///
-    /// ## Limitations
-    ///
-    /// The key produced will never immediately point to an occupied slot, but it may point to a location outside
-    /// the collection which will be created on the next call to [`Arena::insert`].
-    /// If, after calling this function, the arena is mutated in a way that changes its free list or storage
-    /// length — for example via [`Arena::insert`], [`Arena::remove`], etc — then the results of this function
-    /// are no longer accurate to what will be returned from the next [`Arena::insert`] call.
+    /// The returned index is invalidated upon insertion or removal of any element
     pub fn next_index(&self) -> Index {
         if let Some(free_pointer) = self.first_free {
             let slot = free_pointer.slot();

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -207,6 +207,16 @@ impl<T> Arena<T> {
             Entry::Vacant(VacantEntry { arena: self, index })
         }
     }
+
+    /// Gets a vacant entry in the arena, with its key computed up front.
+    ///
+    /// Unlike [`Arena::entry`], `vacant_entry` computes the same key that
+    /// [`Arena::insert`] would produce, without inserting a value yet, using
+    /// [`Arena::next_index`].
+    pub fn vacant_entry(&mut self) -> VacantEntry<'_, T> {
+        let index = self.next_index();
+        VacantEntry { arena: self, index }
+    }
 }
 
 #[cfg(all(test, feature = "std"))]
@@ -335,6 +345,25 @@ mod test {
             }
             Entry::Occupied(_) => panic!("expected vacant"),
         }
+    }
+
+    #[test]
+    fn vacant_entry_key_matches_insert() {
+        let mut arena = Arena::new();
+        let predicted = arena.vacant_entry().key();
+        let actual = arena.insert(10);
+        assert_eq!(predicted, actual);
+    }
+
+    #[test]
+    fn vacant_entry_insert() {
+        let mut arena = Arena::new();
+        let entry = arena.vacant_entry();
+        let key = entry.key();
+
+        let value = entry.insert(42);
+        assert_eq!(*value, 42);
+        assert_eq!(arena[key], 42);
     }
 
     #[test]


### PR DESCRIPTION
Added two useful methods:

`Arena::vacant_entry` which makes a new Entry while computing the next key
`Arena::next_index` which immutably takes Arena and calculates what the next key *would* be.

There's some testing for this but I didn't go sicko mode.

I also edited the Changelog but i'm not sure if you'd prefer to do that yourself!