### PR TITLE
feat: remove all unsafe code from the project

### DIFF
--- a/src/free_pointer.rs
+++ b/src/free_pointer.rs
@@ -12,13 +12,11 @@ pub(crate) struct FreePointer(NonZeroU32);
 impl FreePointer {
     #[must_use]
     pub(crate) fn from_slot(slot: u32) -> Self {
-        let value = slot
-            .checked_add(1)
-            .expect("u32 overflowed calculating free pointer from u32");
-
-        // This is safe because any u32 + 1 that didn't overflow must not be
-        // zero.
-        FreePointer(unsafe { NonZeroU32::new_unchecked(value) })
+        FreePointer(
+            slot.checked_add(1)
+                .and_then(NonZeroU32::new)
+                .expect("u32 overflowed calculating free pointer from u32"),
+        )
     }
 
     #[must_use]

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -23,11 +23,9 @@ impl Generation {
 
     #[must_use]
     pub(crate) fn next(self) -> Self {
-        let last_generation = self.0.get();
-        let next_generation = last_generation.checked_add(1).unwrap_or(1);
+        const ONE: NonZeroU32 = NonZeroU32::new(1).unwrap();
 
-        // This is safe because value that would overflow is instead made 1.
-        Generation(unsafe { NonZeroU32::new_unchecked(next_generation) })
+        Generation(self.0.checked_add(1).unwrap_or(ONE))
     }
 
     pub(crate) const fn to_u32(self) -> u32 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,7 @@ will only require minor version bumps, but will need significant justification.
 */
 
 #![forbid(missing_docs)]
+#![deny(unsafe_code)]
 // This crate is sensitive to integer overflow and wrapping behavior. As such,
 // we should usually use methods like `checked_add` and `checked_sub` instead
 // of the `Add` or `Sub` operators.


### PR DESCRIPTION
I was nerdsniped by #47 and went ahead and removed all the unsafe code in the repo **without** adding runtime unwraps. Well...without adding any *new* runtime unwraps. In reality, both of these were handling the NonZeroU32 was 0 case -- I just rerouted them such that they didn't do a new unwrap.

https://godbolt.org/z/n8Teha5Gc

We have two cases of unsafety: `Generation::next` and `FreePointer::from_slot`. `Generation::next`'s new safe-only implementation produces the exact same bytecode.
Interestingly, `FreePointer::from_slot` is now *faster* while being safe -- we lost one single instruction in the new method. Surely that'll be massive percentage increases in speed!

In all reality, these are minor tweaks with syntax.