### PR TITLE
make `Arena::next_index` public.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,13 @@
 * Implemented `Default` for all iterator types except `Drain`.
 * Added Entry API. ([#50])
 * Added `Arena::vacant_entry` ([#57]) for creating an Entry without a key.
+* Added `Arena::next_index` ([#58]) for finding the next index without mutating the Arena.
 
 [#19]: https://github.com/LPGhatguy/thunderdome/issues/19
 [#43]: https://github.com/LPGhatguy/thunderdome/pull/43
 [#50]: https://github.com/LPGhatguy/thunderdome/issues/50
 [#54]: https://github.com/LPGhatguy/thunderdome/pull/57
+[#58]: https://github.com/LPGhatguy/thunderdome/pull/58
 
 ## [0.6.1] - 2023-06-24
 * Added `Index::DANGLING`.

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -228,7 +228,7 @@ impl<T> Arena<T> {
 
     /// Compute the `Index` that the next call to [`Arena::insert`] would produce,
     /// without mutating the arena.
-    pub(crate) fn next_index(&self) -> Index {
+    pub fn next_index(&self) -> Index {
         if let Some(free_pointer) = self.first_free {
             let slot = free_pointer.slot();
             let empty = self


### PR DESCRIPTION
This makes `Arena::next_index` a public function, which enables knowing the next index which will be used by the arena *without* owning exclusive access to the arena.

Note **this cannot be merged** until #57 is merged.